### PR TITLE
Add a parameter filename and a default filename for steams

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ const mindeeClient = Client({
   receiptToken: "receiptExpenseApiToken",
 });
 
-mindeeClient.invoice.parse("path/to/file", "file");
-mindeeClient.receipt.parse(base64String, "base64");
-mindeeClient.financialDocument.parse(base64String, "base64");
+mindeeClient.invoice.parse({ input: "path/to/file", inputType: "file" });
+mindeeClient.receipt.parse({ input: base64String, inputType: "base64" });
+mindeeClient.financialDocument.parse({
+  input: base64String,
+  inputType: "base64",
+});
 ```
 
 Three apis are actually supported : invoice (`ìnvoice`), receipt (`receipt`) and financial document (`financialDocument`)
@@ -54,7 +57,7 @@ const mindeeClient = new Client();
 
 // parsing invoice from pdf
 mindeeClient.invoice
-  .parse("./documents/invoices/invoice.pdf") // see examples for more input types
+  .parse({ input: "./documents/invoices/invoice.pdf" }) // see examples for more input types
   .then((res) => {
     console.log("Success !");
     console.log(res.invoices);
@@ -66,6 +69,7 @@ mindeeClient.invoice
 ```
 
 ## Parsing receipts
+
 ```js
 const { Client } = require("mindee");
 const fs = require("fs");
@@ -75,7 +79,7 @@ const mindeeClient = new Client();
 
 // parsing receipt from picture
 mindeeClient.receipt
-  .parse("./documents/receipts/receipt.jpg") // see examples for more input types
+  .parse({ input: "./documents/receipts/receipt.jpg" }) // see examples for more input types
   .then((res) => {
     console.log("Success !");
     console.log(res.receipts);
@@ -101,7 +105,7 @@ const mindeeClient = new Client();
 
 // parsing receipt from picture
 mindeeClient.financialDocument
-  .parse("./documents/receipts/receipt.jpg")
+  .parse({ input: "./documents/receipts/receipt.jpg" })
   .then((res) => {
     console.log("Success !");
     console.log(res.financialDocuments);
@@ -110,7 +114,6 @@ mindeeClient.financialDocument
   .catch((err) => {
     console.error(err);
   });
-
 ```
 
 # Tests

--- a/examples/financialDocument.js
+++ b/examples/financialDocument.js
@@ -5,7 +5,7 @@ const mindeeClient = new Client();
 
 // parsing receipt from picture
 mindeeClient.financialDocument
-  .parse("./documents/receipts/receipt.jpg")
+  .parse({ input: "./documents/receipts/receipt.jpg" })
   .then((res) => {
     console.log("Success !");
     console.log(res.financialDocuments);
@@ -21,7 +21,7 @@ const base64 = fs.readFileSync("./documents/receipts/receipt.jpg", {
   encoding: "base64",
 });
 mindeeClient.financialDocument
-  .parse(base64, "base64")
+  .parse({ input: base64, inputType: "base64" })
   .then((res) => {
     console.log("Success !");
     console.log(res.financialDocuments);

--- a/examples/invoice.js
+++ b/examples/invoice.js
@@ -6,7 +6,7 @@ const mindeeClient = new Client();
 
 // parsing invoice from pdf
 mindeeClient.invoice
-  .parse("./documents/invoices/invoice.pdf")
+  .parse({ input: "./documents/invoices/invoice.pdf" })
   .then((res) => {
     console.log("Success !");
     console.log(res.invoices);
@@ -18,7 +18,7 @@ mindeeClient.invoice
 
 // // parsing invoice from multiple page pdf
 mindeeClient.invoice
-  .parse("./documents/invoices/invoice_6p.pdf")
+  .parse({ input: "./documents/invoices/invoice_6p.pdf" })
   .then((res) => {
     console.log("Success !");
     console.log(res.invoices);
@@ -33,7 +33,7 @@ const base64 = fs.readFileSync("./documents/invoices/invoice.pdf", {
   encoding: "base64",
 });
 mindeeClient.invoice
-  .parse(base64, "base64")
+  .parse({ input: base64, inputType: "base64" })
   .then((res) => {
     console.log("Success !");
     console.log(res.invoices);
@@ -46,7 +46,7 @@ mindeeClient.invoice
 // parsing invoice from stream
 const stream = fs.createReadStream("./documents/invoices/invoice.pdf");
 mindeeClient.invoice
-  .parse(stream, "stream")
+  .parse({ input: stream, inputType: "stream" })
   .then((res) => {
     console.log("Success !");
     console.log(res.invoices);

--- a/examples/receipt.js
+++ b/examples/receipt.js
@@ -6,7 +6,7 @@ const mindeeClient = new Client();
 
 // parsing receipt from picture
 mindeeClient.receipt
-  .parse("./documents/receipts/receipt.jpg")
+  .parse({ input: "./documents/receipts/receipt.jpg" })
   .then((res) => {
     console.log("Success !");
     console.log(res.receipts);
@@ -21,7 +21,7 @@ const base64 = fs.readFileSync("./documents/receipts/receipt.jpg", {
   encoding: "base64",
 });
 mindeeClient.receipt
-  .parse(base64, "base64")
+  .parse({ input: base64, inputType: "base64" })
   .then((res) => {
     console.log("Success !");
     console.log(res.receipts);
@@ -34,7 +34,7 @@ mindeeClient.receipt
 // parsing receipt from stream
 const stream = fs.createReadStream("./documents/receipts/receipt.jpg");
 mindeeClient.receipt
-  .parse(stream, "stream")
+  .parse({ input: stream, inputType: "stream" })
   .then((res) => {
     console.log("Success !");
     console.log(res.receipts);

--- a/mindee/api/financialDocument.js
+++ b/mindee/api/financialDocument.js
@@ -19,11 +19,12 @@ class APIFinancialDocument extends APIObject {
   async parse({
     input,
     inputType = "path",
+    filename = undefined,
     version = "3",
     cutPdf = true,
     includeWords = false,
   }) {
-    const inputFile = new Input({ file: input, inputType, cutPdf });
+    const inputFile = new Input({ file: input, inputType, filename, cutPdf });
     this.apiToken =
       inputFile.fileExtension === "pdf" ? this.invoiceToken : this.receiptToken;
     await inputFile.init();

--- a/mindee/api/financialDocument.js
+++ b/mindee/api/financialDocument.js
@@ -16,14 +16,14 @@ class APIFinancialDocument extends APIObject {
    * @param {Boolean} cutPdf: Automatically reconstruct pdf with more than 4 pages
    * @returns {Response} Wrapped response with Receipts objects parsed
    */
-  async parse(
-    file,
+  async parse({
+    input,
     inputType = "path",
     version = "3",
     cutPdf = true,
-    includeWords = false
-  ) {
-    const inputFile = new Input({ file, inputType, cutPdf });
+    includeWords = false,
+  }) {
+    const inputFile = new Input({ file: input, inputType, cutPdf });
     this.apiToken =
       inputFile.fileExtension === "pdf" ? this.invoiceToken : this.receiptToken;
     await inputFile.init();

--- a/mindee/api/invoice.js
+++ b/mindee/api/invoice.js
@@ -18,12 +18,13 @@ class APIInvoice extends APIObject {
   async parse({
     input,
     inputType = "path",
+    filename = undefined,
     version = "2",
     cutPdf = true,
     includeWords = false,
   }) {
     super.parse();
-    const inputFile = new Input({ file: input, inputType, cutPdf });
+    const inputFile = new Input({ file: input, inputType, filename, cutPdf });
     await inputFile.init();
     const url = `v${version}/predict`;
     return await super._request(url, inputFile, includeWords);

--- a/mindee/api/invoice.js
+++ b/mindee/api/invoice.js
@@ -15,15 +15,15 @@ class APIInvoice extends APIObject {
    * @param {String} version: expense_receipt api version
    * @returns {Response} Wrapped response with Receipts objects parsed
    */
-  async parse(
-    file,
+  async parse({
+    input,
     inputType = "path",
     version = "2",
     cutPdf = true,
-    includeWords = false
-  ) {
+    includeWords = false,
+  }) {
     super.parse();
-    const inputFile = new Input({ file, inputType, cutPdf });
+    const inputFile = new Input({ file: input, inputType, cutPdf });
     await inputFile.init();
     const url = `v${version}/predict`;
     return await super._request(url, inputFile, includeWords);

--- a/mindee/api/receipt.js
+++ b/mindee/api/receipt.js
@@ -18,12 +18,13 @@ class APIReceipt extends APIObject {
   async parse({
     input,
     inputType = "path",
+    filename = undefined,
     version = "3",
     cutPdf = true,
     includeWords = false,
   }) {
     super.parse();
-    const inputFile = new Input({ file: input, inputType, cutPdf });
+    const inputFile = new Input({ file: input, inputType, filename, cutPdf });
     await inputFile.init();
     const url = `v${version}/predict`;
     return await super._request(url, inputFile, includeWords);

--- a/mindee/api/receipt.js
+++ b/mindee/api/receipt.js
@@ -15,15 +15,15 @@ class APIReceipt extends APIObject {
    * @param {Boolean} cutPdf: Automatically reconstruct pdf with more than 4 pages
    * @returns {Response} Wrapped response with Receipts objects parsed
    */
-  async parse(
-    file,
+  async parse({
+    input,
     inputType = "path",
     version = "3",
     cutPdf = true,
-    includeWords = false
-  ) {
+    includeWords = false,
+  }) {
     super.parse();
-    const inputFile = new Input({ file, inputType, cutPdf });
+    const inputFile = new Input({ file: input, inputType, cutPdf });
     await inputFile.init();
     const url = `v${version}/predict`;
     return await super._request(url, inputFile, includeWords);

--- a/mindee/api/request.js
+++ b/mindee/api/request.js
@@ -9,13 +9,9 @@ const request = (url, method, headers, input, includeWords = false) => {
     let body;
     headers["User-Agent"] = `mindee-node/${sdkVersion} node/${process.version}`;
 
-    if (input.inputType === "path") {
+    if (["path", "stream"].includes(input.inputType)) {
       const fileParams = { filename: input.filename };
       form.append("file", input.fileObject, fileParams);
-      if (includeWords) form.append("include_mvision", "true");
-      headers = { ...headers, ...form.getHeaders() };
-    } else if (input.inputType === "stream") {
-      form.append("file", input.fileObject);
       if (includeWords) form.append("include_mvision", "true");
       headers = { ...headers, ...form.getHeaders() };
     } else if (input.inputType === "base64") {

--- a/mindee/inputs.js
+++ b/mindee/inputs.js
@@ -55,7 +55,7 @@ class Input {
   async initFile() {
     this.fileObject = await fs.readFile(this.file);
     this.filepath = this.file;
-    this.filename = path.basename(this.file);
+    this.filename = this.filename || path.basename(this.file);
     // Check if file type is valid
     const filetype = this.filename.split(".").pop();
     if (!(filetype in this.MIMETYPES)) {
@@ -76,8 +76,8 @@ class Input {
 
   async initStream() {
     this.fileObject = this.file;
+    this.filename = this.filename || "stream";
     this.filepath = undefined;
-    this.filename = undefined;
   }
 
   initDummy() {


### PR DESCRIPTION
# PR Details

- Add a parameter `filename` that let you choose the filename of the document
- Set a default filename for streams (named `stream`) to fix issue with duplex streams

## Description

- Add a default filename `stream` to streams
- Add a filename parameter that is used to replace filename by default in streams and files (this is not used with base64 data)
- Use this filename in form-data in requests to the API with streams

## Motivation and Context

Fix an issue with duplex streams not working with the SDK

## How Has This Been Tested

- running unit tests
- running examples
- tested with an example from the user that was not working before the fix ([see this repository](https://github.com/fraxken/mindee_stream_repro))

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [x] All new and existing tests passed.
