### PR TITLE
fix: :bug: Updated api Input initialization to specifically declare parameters

### DIFF
--- a/mindee/api/financialDocument.js
+++ b/mindee/api/financialDocument.js
@@ -24,7 +24,12 @@ class APIFinancialDocument extends APIObject {
     cutPdf = true,
     includeWords = false,
   }) {
-    const inputFile = new Input({ file: input, inputType, filename, cutPdf });
+    const inputFile = new Input({
+      file: input,
+      inputType: inputType,
+      filename: filename,
+      allowCutPdf: cutPdf,
+    });
     this.apiToken =
       inputFile.fileExtension === "pdf" ? this.invoiceToken : this.receiptToken;
     await inputFile.init();

--- a/mindee/api/invoice.js
+++ b/mindee/api/invoice.js
@@ -24,7 +24,12 @@ class APIInvoice extends APIObject {
     includeWords = false,
   }) {
     super.parse();
-    const inputFile = new Input({ file: input, inputType, filename, cutPdf });
+    const inputFile = new Input({
+      file: input,
+      inputType: inputType,
+      filename: filename,
+      allowCutPdf: cutPdf,
+    });
     await inputFile.init();
     const url = `v${version}/predict`;
     return await super._request(url, inputFile, includeWords);

--- a/mindee/api/receipt.js
+++ b/mindee/api/receipt.js
@@ -26,8 +26,8 @@ class APIReceipt extends APIObject {
     super.parse();
     const inputFile = new Input({
       file: input,
-      inputType,
-      filename,
+      inputType: inputType,
+      filename: filename,
       allowCutPdf: cutPdf,
     });
     await inputFile.init();


### PR DESCRIPTION
# PR Details

cutPdf parameters form `parse` methods wasn't sent to the Input class the right way.

## Description

Specifically describe the parameters sent for creating Input objects in `parse` methods from Receipt, Invoice, and FinancialDocument API classes.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)