### PR TITLE
fix: 🐛 handle attribute of type array when merging pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,32 @@
 # CHANGELOG
 
+## v1.0.9 (2021-12-09)
+
+### Fixes
+
+- fix: 🐛 handle attribute of type array when merging pages
+
 ## v1.0.8 (2021-11-29)
 
 ### Fixes
+
 - 🐛 fix cutPDF for ReadableStream + add it for base64 file string
 - 🐛 Updated api Input initialization to specifically declare parameters
 - 🐛 prevent error when the mime type isn't detectable
 - 🐛 raise proper error when the APi doesn't return a valid JSON
 
 ### new
+
 - :see_no_evil: add .DS_Store to ignore file
 
 ## v1.0.7 (2021-11-25)
 
 ### New
+
 - ✨ Added pdf page number parameter for multi-pages pdfs with file
 
 ### Changes
+
 - :arrow_up: upgrade path-parse dependency
 - :arrow_up: upgrade browserslist dependency
 - :arrow_up: upgrade lodash dependency
@@ -25,29 +35,31 @@
 ## v1.0.4 (2021-02-18)
 
 ### New
-* :sparkles: :zap: Add a parameter `filename` and a default filename for streams
+
+- :sparkles: :zap: Add a parameter `filename` and a default filename for streams
 
 ### Changes
-* :zap: Change parse function to use an object instead of multiples parameters
 
+- :zap: Change parse function to use an object instead of multiples parameters
 
 ## v1.0.3 (2021-02-01)
 
 ### Fixes
-* :bug: _request parameters
-* :bug: `pageNumber` default value
-* :bug: reconstruction method set fields to probability
 
+- :bug: \_request parameters
+- :bug: `pageNumber` default value
+- :bug: reconstruction method set fields to probability
 
 ## v1.0.2 (2021-02-01)
 
 ### Changes
-* :zap: Better coverage for total tax
+
+- :zap: Better coverage for total tax
 
 ### Fixes
-* :bug: `includeWords` is now working
 
+- :bug: `includeWords` is now working
 
 ## v1.0.1 (2021-01-11)
 
-* 🎉 First release
+- 🎉 First release

--- a/mindee/documents/document.js
+++ b/mindee/documents/document.js
@@ -50,7 +50,11 @@ class Document {
     const attributes = Object.getOwnPropertyNames(finalDocument);
     for (const document of documents) {
       for (const attribute of attributes) {
-        if (
+        if (Array.isArray(document?.[attribute])) {
+          finalDocument[attribute] = finalDocument[attribute]?.length
+            ? finalDocument[attribute]
+            : document?.[attribute];
+        } else if (
           document?.[attribute]?.probability >
           finalDocument[attribute].probability
         ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindee",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Mindee API SDK for Node.js",
   "main": "mindee/index.js",
   "license": "GPL-3.0",


### PR DESCRIPTION
# PR Details

This PR should fix the issue about the Invoice object on API response that doesn't return the array of taxes.

## Description

Given a document of two pages, the invoice API result should contains an object of prediction for each page which will later be merged in on single response sent by the SDK to the user using the `invoice` attribute in this case. The issue come from the function `MergePages` that don't take into account the attributes of type array like `taxes`.

```
static mergePages(documents) {
    const finalDocument = documents[0].clone();
    const attributes = Object.getOwnPropertyNames(finalDocument);
    for (const document of documents) {
      for (const attribute of attributes) {
        if (
          document?.[attribute]?.probability >
          finalDocument[attribute].probability
        ) {
          finalDocument[attribute] = document?.[attribute];
        }
      }
    }
```


