### PR TITLE
fix: 🐛 Get words values when includeWords parameter is true

### DIFF
--- a/mindee/api/financialDocument.js
+++ b/mindee/api/financialDocument.js
@@ -40,7 +40,7 @@ class APIFinancialDocument extends APIObject {
         ? "/invoices/v3/predict"
         : "/expense_receipts/v3/predict";
     super.parse();
-    return await super._request(url, inputFile, version, includeWords);
+    return super._request(url, inputFile, includeWords);
   }
 }
 

--- a/mindee/api/object.js
+++ b/mindee/api/object.js
@@ -10,7 +10,7 @@ const request = require("./request");
 class APIObject {
   constructor(apiToken = undefined, apiName = "") {
     this.apiToken = apiToken;
-    this.baseUrl = "https://api.mindee.net/v1/products/mindee/";
+    this.baseUrl = "https://api.mindee.net/v1/products/mindee";
     this.apiName = apiName;
   }
 

--- a/mindee/api/request.js
+++ b/mindee/api/request.js
@@ -6,7 +6,7 @@ const os = require("os");
 
 const request = (url, method, headers, input, includeWords = false) => {
   return new Promise(function (resolve, reject) {
-    const form = new FormData();
+    let form = new FormData();
     let body;
 
     headers["User-Agent"] = `mindee-api-nodejs@v${sdkVersion} nodejs-${

--- a/mindee/api/response.js
+++ b/mindee/api/response.js
@@ -32,31 +32,47 @@ class Response {
   }
 
   formatResponse() {
+    let http_data_document = this.httpResponse.data.document;
     const constructors = {
       receipt: (params) => new Receipt(params),
       invoice: (params) => new Invoice(params),
       financialDocument: (params) => new FinancialDocument(params),
     };
-    const predictions = this.httpResponse.data.document.inference.pages.entries();
+
+    const predictions = http_data_document.inference.pages.entries();
     this[`${this.documentType}s`] = [];
+    let document_words_content = [];
 
     // Create a list of Document (Receipt, Invoice...) for each page of the input document
     for (const [pageNumber, prediction] of predictions) {
+      let page_words_content = [];
+      if (
+        "ocr" in http_data_document &&
+        Object.keys(http_data_document.ocr).length > 0
+      ) {
+        page_words_content =
+          http_data_document.ocr["mvision-v1"].pages[pageNumber].all_words;
+        document_words_content.push(
+          ...http_data_document.ocr["mvision-v1"].pages[pageNumber].all_words
+        );
+      }
       this[`${this.documentType}s`].push(
         constructors[this.documentType]({
           apiPrediction: prediction.prediction,
           inputFile: this.input,
           pageNumber: pageNumber,
+          words: page_words_content,
         })
       );
     }
 
     // Merge the list of Document into a unique Document
     this[this.documentType] = constructors[this.documentType]({
-      apiPrediction: this.httpResponse.data.document.inference.prediction,
+      apiPrediction: http_data_document.inference.prediction,
       inputFile: this.input,
-      pageNumber: this.httpResponse.data.document.n_pages,
+      pageNumber: http_data_document.n_pages,
       level: "document",
+      words: document_words_content,
     });
   }
 }

--- a/mindee/documents/financialDocument.js
+++ b/mindee/documents/financialDocument.js
@@ -54,6 +54,7 @@ class FinancialDocument extends Document {
     customerName = undefined,
     customerAddress = undefined,
     customerCompanyRegistration = undefined,
+    words = undefined,
     pageNumber = 0,
     level = "page",
   }) {
@@ -82,7 +83,7 @@ class FinancialDocument extends Document {
         customerCompanyRegistration,
       });
     } else {
-      this.#initFromApiPrediction(apiPrediction, inputFile, pageNumber);
+      this.#initFromApiPrediction(apiPrediction, inputFile, pageNumber, words);
     }
     this.#checklist();
   }
@@ -145,13 +146,14 @@ class FinancialDocument extends Document {
     }
   }
 
-  #initFromApiPrediction(apiPrediction, inputFile, pageNumber) {
+  #initFromApiPrediction(apiPrediction, inputFile, pageNumber, words) {
     if (Object.keys(apiPrediction).includes("invoice_number")) {
       const invoice = new Invoice({
         apiPrediction,
         inputFile,
         pageNumber,
         level: this.level,
+        words: words,
       });
       this.locale = invoice.locale;
       this.totalIncl = invoice.totalIncl;
@@ -166,6 +168,7 @@ class FinancialDocument extends Document {
       this.companyNumber = invoice.companyNumber;
       this.orientation = invoice.orientation;
       this.totalTax = invoice.totalTax;
+      if (invoice.words) this.words = invoice.words;
       this.time = new Field({
         prediction: { value: undefined, confidence: 0.0 },
       });
@@ -178,6 +181,7 @@ class FinancialDocument extends Document {
         inputFile,
         pageNumber,
         level: this.level,
+        words: words,
       });
       this.orientation = receipt.orientation;
       this.date = receipt.date;
@@ -208,6 +212,7 @@ class FinancialDocument extends Document {
         prediction: { value: undefined, confidence: 0.0 },
       });
       this.customerCompanyRegistration = [];
+      if (receipt.words) this.words = receipt.words;
     }
   }
 

--- a/mindee/documents/invoice.js
+++ b/mindee/documents/invoice.js
@@ -50,6 +50,7 @@ class Invoice extends Document {
     customerName = undefined,
     customerAddress = undefined,
     customerCompanyRegistration = undefined,
+    words = undefined,
     pageNumber = 0,
     level = "page",
   }) {
@@ -80,7 +81,7 @@ class Invoice extends Document {
         customerCompanyRegistration,
       });
     } else {
-      this.#initFromApiPrediction(apiPrediction, pageNumber);
+      this.#initFromApiPrediction(apiPrediction, pageNumber, words);
     }
     this.#checklist();
     this.#reconstruct();
@@ -142,8 +143,7 @@ class Invoice extends Document {
     }
   }
 
-  #initFromApiPrediction(apiPrediction, pageNumber) {
-    this.words = [];
+  #initFromApiPrediction(apiPrediction, pageNumber, words) {
     this.locale = new Locale({ prediction: apiPrediction.locale, pageNumber });
     this.totalIncl = new Amount({
       prediction: apiPrediction.total_incl,
@@ -243,8 +243,7 @@ class Invoice extends Document {
         })
       );
     }
-    // document.inference.ocr
-    if ("mvision" in apiPrediction) this.words = apiPrediction.mvision;
+    if (words && words.length > 0) this.words = words;
   }
 
   toString() {

--- a/mindee/documents/receipt.js
+++ b/mindee/documents/receipt.js
@@ -37,6 +37,7 @@ class Receipt extends Document {
     orientation = undefined,
     totalTax = undefined,
     totalExcl = undefined,
+    words = undefined,
     pageNumber = 0,
     level = "page",
   }) {
@@ -60,7 +61,7 @@ class Receipt extends Document {
         pageNumber,
       });
     } else {
-      this.#initFromApiPrediction(apiPrediction, pageNumber);
+      this.#initFromApiPrediction(apiPrediction, pageNumber, words);
     }
     this.#checklist();
     this.#reconstruct();
@@ -108,8 +109,7 @@ class Receipt extends Document {
     @param apiPrediction: Raw prediction from HTTP response
     @param pageNumber: Page number for multi pages pdf input
    */
-  #initFromApiPrediction(apiPrediction, pageNumber) {
-    this.words = [];
+  #initFromApiPrediction(apiPrediction, pageNumber, words) {
     this.locale = new Locale({ prediction: apiPrediction.locale, pageNumber });
     this.totalIncl = new Amount({
       prediction: apiPrediction.total_incl,
@@ -171,7 +171,7 @@ class Receipt extends Document {
         })
       );
     }
-    if ("mvision" in apiPrediction) this.words = apiPrediction.mvision;
+    if (words && words.length > 0) this.words = words;
   }
 
   toString() {

--- a/tests/api/apiObject.js
+++ b/tests/api/apiObject.js
@@ -10,7 +10,7 @@ describe("test APIObject", () => {
     expect(apiObject.apiToken).to.be.equal("dummyToken");
     expect(apiObject.apiName).to.be.equal("dummyApiName");
     expect(apiObject.baseUrl).to.be.equal(
-      "https://api.mindee.net/v1/products/mindee/"
+      "https://api.mindee.net/v1/products/mindee"
     );
   });
 


### PR DESCRIPTION
# PR Details

Get words values when includeWords parameter is true

## Description

Since v1.1.0, the parameter includeWords is not interpreted and its value is never returned by the client library

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [x] All new and existing tests passed.
