### PR TITLE
chg: 📝 prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.2.0
+
+### Fixes
+
+- fix: 🐛 Get words values when includeWords parameter is true
+
 ## v1.1.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- fix: 🐛 Get words values when includeWords parameter is true
+- fix: 🐛 Get `words` values when `includeWords` parameter is `true`
 
 ## v1.1.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mindee",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mindee",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-arraybuffer": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindee",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Mindee API SDK for Node.js",
   "main": "mindee/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
# PR Details

Get words values when includeWords parameter is true

## Description

Since v1.1.0, the parameter includeWords is not interpreted and its value is never returned by the client library

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [x] All new and existing tests passed.
