### PR TITLE
Always send the file name to the API.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 on:
-  - pull_request
+  - push
 
 jobs:
   run-linters:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  - pull_request
+  - push
 
 jobs:
   run-tests:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# API SDK for Node.js
+# Mindee Client Library for Node.js
 
 # Installation
 
@@ -35,9 +35,22 @@ mindeeClient.financialDocument.parse({
 });
 ```
 
-Three apis are actually supported : invoice (`ìnvoice`), receipt (`receipt`) and financial document (`financialDocument`)
+Three APIs are actually supported: invoice (`ìnvoice`), receipt (`receipt`) and financial document (`financialDocument`)
 
 You can find more examples on how to use the SDK into the folder `examples`.
+
+## MIME Types
+When using `stream` or `base64` inputs, the MIME type is guessed using magic numbers.
+In some cases, for example with non-standard files, it will not be possible to detect the MIME type in this way.
+
+If you are getting MIME type errors, you will need to specify a file name having the correct extension, for example:
+```js
+mindeeClient.invoice.parse({
+  input: base64String,
+  inputType: "base64",
+  filename: "myfile.pdf",
+});
+```
 
 ## Client
 

--- a/mindee/inputs.js
+++ b/mindee/inputs.js
@@ -52,18 +52,24 @@ class Input {
   async initBase64() {
     this.fileObject = this.file;
     this.filepath = undefined;
-    this.fileExtension = undefined;
 
-    if (this.allowCutPdf == true) {
-      const typeOfFile = await fileType.fromBuffer(
+    if (this.filename === undefined) {
+      const mimeType = await fileType.fromBuffer(
         Buffer.from(this.fileObject, "base64")
       );
-
-      if (typeOfFile === undefined) {
-        console.error(`Cannot detect mime type of: ${this.fileObject}`);
-      } else if (typeOfFile.mime === "application/pdf") {
-        await this.cutPdf();
+      if (mimeType !== undefined) {
+        this.fileExtension = mimeType.mime;
+        this.filename = `from_${this.inputType}.${mimeType.ext}`;
+      } else {
+        throw "Could not determine the MIME type. Please specify the 'filename' option.";
       }
+    } else {
+      const filetype = this.filename.split(".").pop();
+      this.fileExtension = this.MIMETYPES[filetype];
+    }
+
+    if (this.fileExtension === "application/pdf" && this.allowCutPdf == true) {
+      await this.cutPdf();
     }
   }
 


### PR DESCRIPTION
# Always send the file name to the API

When working with streams or base 64 encoded strings:
* Allow the user to send the file name, if set, use this to determine file type based on the extension.
* If the file name is not set, generate a file name based on the detected MIME type.
* If we can't determine the MIME type (for a corrupt or non-standard file for example), force the user to set the filename when calling the `parse` function.

## Motivation and Context

Currently there is no recourse for a user if the stream contents cannot be used to determine the MIME type.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
