### PR TITLE
🐛 forward api error to stderr instead of stdout

### DIFF
--- a/mindee/api/request.js
+++ b/mindee/api/request.js
@@ -50,7 +50,7 @@ const request = (url, method, headers, input, includeWords = false) => {
             data: JSON.parse(responseBody),
           });
         } catch (error) {
-          console.log(responseBody, error);
+          console.error(responseBody, error);
         }
       });
     });


### PR DESCRIPTION
# PR Details

The old code was sending errors to stdout which make hard to detect issues when API request are failing (logs are not where we expect them).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Running `npm test` (by the way some tests fail on Windows.. related to pdf cut).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [ ] All new and existing tests passed.
