### PR TITLE
🐛 use pdf length instead of cut pdf size limit

### DIFF
--- a/mindee/inputs.js
+++ b/mindee/inputs.js
@@ -143,10 +143,7 @@ class Input {
     const splitedPdfDocument = await PDFDocument.create();
     const pdfLength = pdfDocument.getPageCount();
     if (pdfLength <= this.CUT_PDF_SIZE) return;
-    const pagesNumbers = [
-      ...Array(this.CUT_PDF_SIZE - 1).keys(),
-      pdfLength - 1,
-    ];
+    const pagesNumbers = [...Array(pdfLength - 1).keys(), pdfLength - 1];
     const pages = await splitedPdfDocument.copyPages(pdfDocument, pagesNumbers);
     pages.forEach((page) => splitedPdfDocument.addPage(page));
     const data = await splitedPdfDocument.save();


### PR DESCRIPTION
# PR Details

The old code was always working with the same limit of pages for a pdf document (which was a limit a 5 pages). Because of that the client library was loosing datas from the API response when the pdf had more than 5 pages. If the data was discovered in only one page, the client library would never get it because the asynchronous processing would catch the empty values first.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Running `npm test` (by the way some tests fail on Windows.. related to pdf cut).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [ ] All new and existing tests passed.
