### PR TITLE
🐛 reject error instead of only print it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.3.3
+
+### Fixes
+* 🐛 reject error instead of only print it
+
 ## v1.3.2
 
 ### Fixes

--- a/mindee/api/request.js
+++ b/mindee/api/request.js
@@ -50,7 +50,7 @@ const request = (url, method, headers, input, includeWords = false) => {
             data: JSON.parse(responseBody),
           });
         } catch (error) {
-          console.error(responseBody, error);
+          reject(error);
         }
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "mindee",
-  "version": "1.2.0",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mindee",
-      "version": "1.2.0",
-      "license": "Apache-2.0",
+      "version": "1.3.3",
+      "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2",
         "base64-stream": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindee",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Mindee Client Library for Node.js",
   "main": "mindee/index.js",
   "license": "MIT",


### PR DESCRIPTION
# PR Details

The issue was that some errors were detected but the script wouldn't stop. Because the error was printed instead rejected inside the promise.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

Running `npm test`.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [ ] All new and existing tests passed.
