### PR TITLE
Fix encrypted PDF

### DIFF
--- a/mindee/errors/handler.js
+++ b/mindee/errors/handler.js
@@ -1,4 +1,4 @@
-const logger = require("../logger");
+const { logger } = require("../logger");
 
 class ErrorHandler {
   constructor(throwOnError = true) {

--- a/mindee/index.js
+++ b/mindee/index.js
@@ -1,5 +1,5 @@
 const errorHandler = require("./errors/handler");
-const logger = require("./logger");
+const { logger, LOG_LEVELS } = require("./logger");
 const APIReceipt = require("./api/receipt");
 const APIInvoice = require("./api/invoice");
 const APIFinancialDocument = require("./api/financialDocument");
@@ -20,7 +20,10 @@ class Client {
     this.receiptToken = receiptToken || process.env.MINDEE_RECEIPT_TOKEN;
     this.invoiceToken = invoiceToken || process.env.MINDEE_INVOICE_TOKEN;
     errorHandler.throwOnError = throwOnError;
-    logger.level = debug ?? process.env.MINDEE_DEBUG ? "debug" : "warn";
+    logger.level =
+      debug ?? process.env.MINDEE_DEBUG
+        ? LOG_LEVELS["debug"]
+        : LOG_LEVELS["warn"];
     this.receipt = new APIReceipt(this.receiptToken);
     this.invoice = new APIInvoice(this.invoiceToken);
     this.financialDocument = new APIFinancialDocument(

--- a/mindee/inputs.js
+++ b/mindee/inputs.js
@@ -6,6 +6,7 @@ const concat = require("concat-stream");
 const { Base64Encode } = require("base64-stream");
 const fileType = require("file-type");
 const ArrayBufferEncode = require("base64-arraybuffer");
+const { logger } = require("./logger");
 
 class Input {
   MIMETYPES = {
@@ -148,6 +149,14 @@ class Input {
 
     const pdfLength = currentPdf.getPageCount();
     if (pdfLength <= this.MAX_DOC_PAGES) {
+      return;
+    }
+
+    if (currentPdf.isEncrypted) {
+      logger.error(
+        "PDF of %d pages is encrypted, not possible to cut pages.",
+        pdfLength
+      );
       return;
     }
 

--- a/mindee/logger.js
+++ b/mindee/logger.js
@@ -12,22 +12,23 @@ class Logger {
   }
 
   debug(...args) {
-    if (this.level <= LOGGER_LEVELS["debug"]) console.debug(args);
+    if (this.level <= LOGGER_LEVELS["debug"]) console.debug(...args);
   }
 
   info(...args) {
-    if (this.level <= LOGGER_LEVELS["info"]) console.info(args);
+    if (this.level <= LOGGER_LEVELS["info"]) console.info(...args);
   }
 
   warn(...args) {
-    if (this.level <= LOGGER_LEVELS["warn"]) console.warn(args);
+    if (this.level <= LOGGER_LEVELS["warn"]) console.warn(...args);
   }
 
   error(...args) {
-    if (this.level <= LOGGER_LEVELS["error"]) console.error(args);
+    if (this.level <= LOGGER_LEVELS["error"]) console.error(...args);
   }
 }
 
-const logger = new Logger();
-
-module.exports = logger;
+module.exports = {
+  logger: new Logger(),
+  LOG_LEVELS: LOGGER_LEVELS,
+};


### PR DESCRIPTION
# :bug: cutting pages of an encrypted PDF leads to unexpected results

When a PDF has more than 3 pages, but is encrypted.

* better to send the encrypted PDF as-is rather than risk corrupting it
* log an error mentioning we couldn't cut the PDF
* the server will count the pages and possibly return an error (depends on the endpoint's settings), this will be caught by the client

## Related Issue

#64 

## How Has This Been Tested

Tested with sample files from a customer.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added type hints (flow) to cover my changes.
- [x] All new and existing tests passed.
