### PR TITLE
Add cropper endpoint and feature

### DIFF
--- a/src/api/endpoint.ts
+++ b/src/api/endpoint.ts
@@ -42,7 +42,7 @@ export class Endpoint {
   /**
    * Make a prediction request.
    */
-  predictRequest(input: Input, includeWords = false) {
+  predictRequest(input: Input, includeWords = false, cropper = false) {
     return new Promise((resolve, reject) => {
       const form = new FormData();
       let body;
@@ -51,26 +51,17 @@ export class Endpoint {
         Authorization: `Token ${this.apiKey}`,
       };
 
-      // TODO: redo this section given there should only
-      //       be a single way of reading the input doc
-      if (["path", "stream"].includes(input.inputType)) {
-        const fileParams = { filename: input.filename };
-        form.append("document", input.fileObject, fileParams);
-        if (includeWords) {
-          form.append("include_mvision", "true");
-        }
-        headers = { ...headers, ...form.getHeaders() };
-      } else if (input.inputType === "base64") {
-        const bodyObj: any = { document: input.fileObject };
-        if (includeWords) {
-          bodyObj["include_mvision"] = "true";
-        }
-        body = JSON.stringify(bodyObj);
-        headers["Content-Type"] = "application/json";
-        headers["Content-Length"] = body.length;
-      }
-
       const uri = new URL(`${this.urlRoot}/predict`);
+      const fileParams = { filename: input.filename };
+      form.append("document", input.fileObject, fileParams);
+      if (includeWords) {
+        form.append("include_mvision", "true");
+      }
+      if (cropper) {
+        uri.searchParams.append("cropper", "true");
+      }
+      headers = { ...headers, ...form.getHeaders() };
+
       const options = {
         method: "POST",
         headers: headers,
@@ -142,6 +133,12 @@ export class ReceiptEndpoint extends Endpoint {
 export class PassportEndpoint extends Endpoint {
   constructor(apiKey: string) {
     super(STANDARD_API_OWNER, "passport", "1", apiKey);
+  }
+}
+
+export class CropperEndpoint extends Endpoint {
+  constructor(apiKey: string) {
+    super(STANDARD_API_OWNER, "cropper", "1", apiKey);
   }
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,7 @@ export {
   FinancialDocResponse,
   PassportResponse,
   CustomResponse,
+  CropperResponse,
 } from "./response";
 export {
   Endpoint,
@@ -12,6 +13,7 @@ export {
   ReceiptEndpoint,
   PassportEndpoint,
   CustomEndpoint,
+  CropperEndpoint,
   STANDARD_API_OWNER,
   API_KEY_ENVVAR_NAME,
 } from "./endpoint";

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -6,6 +6,7 @@ import {
   FinancialDocument,
   CustomDocument,
   DocumentConstructorProps,
+  Cropper,
 } from "../documents";
 import { FullText } from "../fields";
 import { Input } from "../inputs";
@@ -64,7 +65,9 @@ export class CustomResponse extends Response<CustomDocument> {
     httpDataDocument.inference.pages.forEach((apiPage: stringDict) => {
       this.pages.push(
         new CustomDocument({
-          apiPrediction: apiPage.prediction,
+          prediction: apiPage.prediction,
+          orientation: apiPage.orientation,
+          extras: apiPage.extras,
           inputFile: this.inputFile,
           pageId: apiPage.id,
           documentType: this.documentType,
@@ -72,16 +75,18 @@ export class CustomResponse extends Response<CustomDocument> {
       );
     });
     this.document = new CustomDocument({
-      apiPrediction: httpDataDocument.inference.prediction,
+      prediction: httpDataDocument.inference.prediction,
       inputFile: this.inputFile,
       documentType: this.documentType,
+      orientation: {},
+      extras: {},
     });
   }
 }
 
 type StandardDocumentSig<DocType extends Document> = {
   new ({
-    apiPrediction,
+    prediction,
     inputFile,
     pageId,
     fullText,
@@ -113,16 +118,20 @@ export class StandardProductResponse<
       const pageText = this.getPageText(httpDataDocument, apiPage.id);
       this.pages.push(
         new this.documentClass({
-          apiPrediction: apiPage.prediction,
+          prediction: apiPage.prediction,
           inputFile: this.inputFile,
           pageId: apiPage.id,
+          orientation: apiPage.orientation,
+          extras: apiPage.extras,
           fullText: pageText,
         })
       );
     });
     this.document = new this.documentClass({
-      apiPrediction: httpDataDocument.inference.prediction,
+      prediction: httpDataDocument.inference.prediction,
       inputFile: this.inputFile,
+      orientation: {},
+      extras: {},
     });
   }
 }
@@ -148,5 +157,11 @@ export class FinancialDocResponse extends StandardProductResponse<FinancialDocum
 export class PassportResponse extends StandardProductResponse<Passport> {
   constructor(params: ResponseProps) {
     super(Passport, params);
+  }
+}
+
+export class CropperResponse extends StandardProductResponse<Cropper> {
+  constructor(params: ResponseProps) {
+    super(Cropper, params);
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ async function predictCall(command: string, inputPath: string, options: any) {
     });
   }
   const doc = mindeeClient.docFromPath(inputPath);
-  const params = {
+  const predictParams = {
     docType: command === COMMAND_CUSTOM ? options.documentType : conf.docType,
     username: command === COMMAND_CUSTOM ? options.user : STANDARD_API_OWNER,
     cutPages: options.cutPages,
@@ -64,22 +64,32 @@ async function predictCall(command: string, inputPath: string, options: any) {
   let response;
   switch (command) {
     case COMMAND_INVOICE:
-      response = await doc.parse(InvoiceResponse, params);
+      response = await doc.parse(InvoiceResponse, predictParams);
       break;
     case COMMAND_RECEIPT:
-      response = await doc.parse(ReceiptResponse, params);
+      response = await doc.parse(ReceiptResponse, predictParams);
       break;
     case COMMAND_FINANCIAL:
-      response = await doc.parse(FinancialDocResponse, params);
+      response = await doc.parse(FinancialDocResponse, predictParams);
       break;
     case COMMAND_PASSPORT:
-      response = await doc.parse(PassportResponse, params);
+      response = await doc.parse(PassportResponse, predictParams);
       break;
     case COMMAND_CUSTOM:
-      response = await doc.parse(CustomResponse, params);
+      response = await doc.parse(CustomResponse, predictParams);
       break;
     default:
       throw `Unhandled command: ${command}`;
+  }
+  if (options.fullText) {
+    response.pages.forEach((page) => {
+      console.log(page.fullText?.toString());
+    });
+  }
+  if (options.pages) {
+    response.pages.forEach((page) => {
+      console.log(`\n${page}`);
+    });
   }
   if (response.document) {
     console.log(`\n${response.document}`);
@@ -96,6 +106,7 @@ export function cli() {
 
     prog.option("-k, --api-key <api_key>", "API key for document endpoint");
     prog.option("-C, --no-cut-pages", "Don't cut document pages");
+    prog.option("-p, --pages", "Show pages content");
     if (info.fullText) {
       prog.option("-t, --full-text", "Include full document text in response");
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
 } from "./inputs";
 import { Response, STANDARD_API_OWNER } from "./api";
 import {
+  DOC_TYPE_CROPPER,
   DOC_TYPE_FINANCIAL,
   DOC_TYPE_INVOICE,
   DOC_TYPE_PASSPORT,
@@ -14,6 +15,7 @@ import {
   Document,
 } from "./documents";
 import {
+  CropperConfig,
   CustomDocConfig,
   DocumentConfig,
   FinancialDocConfig,
@@ -34,6 +36,7 @@ interface PredictOptions {
   username?: string;
   cutPages?: boolean;
   fullText?: boolean;
+  cropper?: boolean;
 }
 
 class DocumentClient {
@@ -52,10 +55,12 @@ class DocumentClient {
       username: "",
       cutPages: true,
       fullText: false,
+      cropper: false,
     }
   ): Promise<RespType> {
     // seems like there should be a better way of doing this
     const fullText = params?.fullText !== undefined ? params.fullText : false;
+    const cropper = params?.cropper !== undefined ? params.cropper : false;
     const cutPages = params?.cutPages !== undefined ? params.cutPages : true;
     const docType: string =
       params.docType === undefined || params.docType === ""
@@ -88,6 +93,7 @@ class DocumentClient {
       inputDoc: this.inputDoc,
       includeWords: fullText,
       cutPages: cutPages,
+      cropper: cropper,
     });
   }
 
@@ -152,6 +158,10 @@ export class Client {
     this.docConfigs.set(
       [STANDARD_API_OWNER, DOC_TYPE_PASSPORT],
       new PassportConfig(this.apiKey)
+    );
+    this.docConfigs.set(
+      [STANDARD_API_OWNER, DOC_TYPE_CROPPER],
+      new CropperConfig(this.apiKey)
     );
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import {
+  CropperResponse,
   CustomResponse,
   FinancialDocResponse,
   InvoiceResponse,
@@ -12,6 +13,7 @@ import {
   DOC_TYPE_INVOICE,
   DOC_TYPE_PASSPORT,
   DOC_TYPE_RECEIPT,
+  DOC_TYPE_CROPPER,
   Document,
 } from "./documents";
 
@@ -52,6 +54,12 @@ export class ProductConfigs {
       description: "A custom document",
       docType: DOC_TYPE_CUSTOM,
       responseClass: CustomResponse,
+      fullText: false,
+    },
+    {
+      description: "Cropper",
+      docType: DOC_TYPE_CROPPER,
+      responseClass: CropperResponse,
       fullText: false,
     },
   ];

--- a/src/documents/cropper.ts
+++ b/src/documents/cropper.ts
@@ -1,0 +1,37 @@
+import { Document, DocumentConstructorProps } from "./document";
+import { CropperField } from "../fields";
+
+export class Cropper extends Document {
+  cropping: CropperField[] = [];
+
+  constructor({
+    prediction,
+    orientation = undefined,
+    inputFile = undefined,
+    pageId = undefined,
+  }: DocumentConstructorProps) {
+    super({ inputFile, pageId, orientation });
+    if (pageId !== undefined) {
+      prediction.cropping.forEach((crop: any) => {
+        this.cropping.push(
+          new CropperField({
+            prediction: crop,
+            pageId: pageId,
+          })
+        );
+      });
+    }
+  }
+
+  toString(): string {
+    const cropping = this.cropping
+      .map((crop) => crop.toString())
+      .join("\n          ");
+    const outStr = `----- Cropper Data -----
+Filename: ${this.filename}
+Cropping: ${cropping}
+------------------------
+`;
+    return Cropper.cleanOutString(outStr);
+  }
+}

--- a/src/documents/custom.ts
+++ b/src/documents/custom.ts
@@ -1,6 +1,6 @@
 import { Document, DocumentConstructorProps } from "./document";
 import { ClassificationField, ListField } from "../fields";
-import { stringDict } from "../fields/field";
+import { stringDict } from "../fields";
 
 export interface CustomDocConstructorProps extends DocumentConstructorProps {
   documentType: string;
@@ -13,15 +13,17 @@ export class CustomDocument extends Document {
 
   constructor({
     inputFile,
-    apiPrediction,
+    prediction,
+    extras = undefined,
+    orientation = undefined,
     pageId,
     documentType,
   }: CustomDocConstructorProps) {
-    super(inputFile, pageId);
+    super({ inputFile, pageId, orientation, extras });
     this.documentType = documentType;
 
-    Object.keys(apiPrediction).forEach((fieldName) => {
-      this.setField(fieldName, apiPrediction, pageId);
+    Object.keys(prediction).forEach((fieldName) => {
+      this.setField(fieldName, prediction, pageId);
     });
   }
 

--- a/src/documents/financialDocument.ts
+++ b/src/documents/financialDocument.ts
@@ -6,7 +6,6 @@ import {
   Field,
   Amount,
   Locale,
-  Orientation,
   DateField as Date,
   CompanyRegistration,
 } from "../fields";
@@ -19,7 +18,6 @@ export class FinancialDocument extends Document {
   dueDate!: Date;
   category!: Field;
   time!: Field;
-  orientation: Orientation | undefined;
   taxes: TaxField[] = [];
   totalTax!: Amount;
   totalExcl!: Amount;
@@ -32,33 +30,39 @@ export class FinancialDocument extends Document {
   paymentDetails: Field[] = [];
   customerCompanyRegistration: CompanyRegistration[] = [];
 
-  /**
-   * @param {Object} apiPrediction - Json parsed prediction from HTTP response
-   * @param {Input} inputFile - input file given to parse the document
-   * @param {number} pageId - Page ID for multi-page document
-   * @param {FullText} fullText - full OCR extracted text
-   */
   constructor({
-    apiPrediction,
+    prediction,
+    orientation = undefined,
+    extras = undefined,
     inputFile = undefined,
     fullText = undefined,
     pageId = undefined,
   }: DocumentConstructorProps) {
-    super(inputFile, pageId, fullText);
-    this.#initFromApiPrediction(apiPrediction, inputFile, pageId);
+    super({ inputFile, pageId, fullText, orientation, extras });
+    this.#initFromApiPrediction(
+      prediction,
+      inputFile,
+      pageId,
+      orientation,
+      extras
+    );
     this.#checklist();
   }
 
   #initFromApiPrediction(
     prediction: any,
     inputFile: any,
-    pageNumber: number | undefined
+    pageNumber: number | undefined,
+    orientation: any,
+    extras: any
   ) {
     if (Object.keys(prediction).includes("invoice_number")) {
       const invoice = new Invoice({
-        apiPrediction: prediction,
+        prediction: prediction,
         inputFile,
         pageId: pageNumber,
+        orientation: orientation,
+        extras: extras,
       });
       this.locale = invoice.locale;
       this.totalIncl = invoice.totalIncl;
@@ -81,9 +85,11 @@ export class FinancialDocument extends Document {
       this.customerCompanyRegistration = invoice.customerCompanyRegistration;
     } else {
       const receipt = new Receipt({
-        apiPrediction: prediction,
+        prediction: prediction,
         inputFile,
         pageId: pageNumber,
+        orientation: orientation,
+        extras: extras,
       });
       this.orientation = receipt.orientation;
       this.date = receipt.date;

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -3,12 +3,21 @@ import { Receipt } from "./receipt";
 import { Passport } from "./passport";
 import { FinancialDocument } from "./financialDocument";
 import { CustomDocument } from "./custom";
+import { Cropper } from "./cropper";
 
 export { Document, DocumentConstructorProps } from "./document";
-export { Receipt, Invoice, FinancialDocument, Passport, CustomDocument };
+export {
+  Receipt,
+  Invoice,
+  FinancialDocument,
+  Passport,
+  CustomDocument,
+  Cropper,
+};
 
 export const DOC_TYPE_INVOICE = Invoice.name;
 export const DOC_TYPE_RECEIPT = Receipt.name;
 export const DOC_TYPE_PASSPORT = Passport.name;
 export const DOC_TYPE_FINANCIAL = FinancialDocument.name;
 export const DOC_TYPE_CUSTOM = CustomDocument.name;
+export const DOC_TYPE_CROPPER = Cropper.name;

--- a/src/documents/invoice.ts
+++ b/src/documents/invoice.ts
@@ -4,7 +4,6 @@ import {
   BaseField,
   TaxField,
   PaymentDetails,
-  Orientation,
   Locale,
   Amount,
   Field,
@@ -19,7 +18,6 @@ export class Invoice extends Document {
   date!: DateField;
   dueDate!: DateField;
   time!: Field;
-  orientation!: Orientation;
   totalTax!: Amount;
   totalExcl!: Amount;
   supplier!: Field;
@@ -32,20 +30,16 @@ export class Invoice extends Document {
   paymentDetails: PaymentDetails[] = [];
   customerCompanyRegistration: CompanyRegistration[] = [];
 
-  /**
-   * @param {Object} apiPrediction - Json parsed prediction from HTTP response
-   * @param {Input} inputFile - input file given to parse the document
-   * @param {number} pageId - Page ID for multi-page document
-   * @param {FullText} fullText - full OCR extracted text
-   */
   constructor({
-    apiPrediction,
+    prediction,
+    orientation = undefined,
+    extras = undefined,
     inputFile = undefined,
     fullText = undefined,
     pageId = undefined,
   }: DocumentConstructorProps) {
-    super(inputFile, pageId, fullText);
-    this.#initFromApiPrediction(apiPrediction, pageId);
+    super({ inputFile, pageId, fullText, orientation, extras });
+    this.#initFromApiPrediction(prediction, pageId);
     this.#checklist();
     this.#reconstruct();
   }
@@ -138,12 +132,6 @@ export class Invoice extends Document {
         })
       )
     );
-    if (pageId !== undefined) {
-      this.orientation = new Orientation({
-        prediction: apiPrediction.orientation,
-        pageId: pageId,
-      });
-    }
   }
 
   toString(): string {

--- a/src/documents/passport.ts
+++ b/src/documents/passport.ts
@@ -18,59 +18,55 @@ export class Passport extends Document {
   fullName: Field;
   mrz: Field;
 
-  /**
-   * @param {Object} apiPrediction - Json parsed prediction from HTTP response
-   * @param {Input} inputFile - input file given to parse the document
-   * @param {number} pageId - Page ID for multi-page document
-   * @param {FullText} fullText - full OCR extracted text
-   */
   constructor({
-    apiPrediction,
+    prediction,
+    orientation = undefined,
+    extras = undefined,
     inputFile = undefined,
     pageId = undefined,
   }: DocumentConstructorProps) {
-    super(inputFile, pageId);
+    super({ inputFile, pageId, orientation, extras });
     this.country = new Field({
-      prediction: apiPrediction.country,
+      prediction: prediction.country,
       pageId: pageId,
     });
     this.idNumber = new Field({
-      prediction: apiPrediction.id_number,
+      prediction: prediction.id_number,
       pageId: pageId,
     });
     this.birthDate = new DateField({
-      prediction: apiPrediction.birth_date,
+      prediction: prediction.birth_date,
       pageId: pageId,
     });
     this.expiryDate = new DateField({
-      prediction: apiPrediction.expiry_date,
+      prediction: prediction.expiry_date,
       pageId: pageId,
     });
     this.issuanceDate = new DateField({
-      prediction: apiPrediction.issuance_date,
+      prediction: prediction.issuance_date,
       pageId: pageId,
     });
     this.birthPlace = new Field({
-      prediction: apiPrediction.birth_place,
+      prediction: prediction.birth_place,
       pageId: pageId,
     });
     this.gender = new Field({
-      prediction: apiPrediction.gender,
+      prediction: prediction.gender,
       pageId: pageId,
     });
     this.surname = new Field({
-      prediction: apiPrediction.surname,
+      prediction: prediction.surname,
       pageId: pageId,
     });
     this.mrz1 = new Field({
-      prediction: apiPrediction.mrz1,
+      prediction: prediction.mrz1,
       pageId: pageId,
     });
     this.mrz2 = new Field({
-      prediction: apiPrediction.mrz2,
+      prediction: prediction.mrz2,
       pageId: pageId,
     });
-    apiPrediction.given_names.map((prediction: { [index: string]: any }) =>
+    prediction.given_names.map((prediction: { [index: string]: any }) =>
       this.givenNames.push(
         new Field({
           prediction: prediction,

--- a/src/documents/receipt.ts
+++ b/src/documents/receipt.ts
@@ -1,12 +1,5 @@
 import { Document, DocumentConstructorProps } from "./document";
-import {
-  TaxField,
-  Field,
-  Amount,
-  Locale,
-  Orientation,
-  DateField,
-} from "../fields";
+import { TaxField, Field, Amount, Locale, DateField } from "../fields";
 
 export class Receipt extends Document {
   locale: Locale;
@@ -16,27 +9,22 @@ export class Receipt extends Document {
   category!: Field;
   merchantName!: Field;
   time!: Field;
-  orientation: Orientation | undefined;
   totalTax: Amount;
   totalExcl: Amount;
   taxes: TaxField[] = [];
 
-  /**
-   * @param {Object} apiPrediction - Json parsed prediction from HTTP response
-   * @param {Input} inputFile - input file given to parse the document
-   * @param {number} pageId - Page ID for multi-page document
-   * @param {FullText} fullText - full OCR extracted text
-   */
   constructor({
-    apiPrediction,
+    prediction,
+    orientation = undefined,
+    extras = undefined,
     inputFile = undefined,
     fullText = undefined,
     pageId = undefined,
   }: DocumentConstructorProps) {
-    super(inputFile, pageId, fullText);
+    super({ inputFile, pageId, fullText, orientation, extras });
 
     this.locale = new Locale({
-      prediction: apiPrediction.locale,
+      prediction: prediction.locale,
       pageId: pageId,
     });
     this.totalTax = new Amount({
@@ -50,7 +38,7 @@ export class Receipt extends Document {
       pageId: pageId,
     });
 
-    this.#initFromApiPrediction(apiPrediction, pageId);
+    this.#initFromApiPrediction(prediction, pageId);
     this.#checklist();
     this.#reconstruct();
   }
@@ -88,12 +76,6 @@ export class Receipt extends Document {
         })
       )
     );
-    if (pageId !== undefined) {
-      this.orientation = new Orientation({
-        prediction: apiPrediction.orientation,
-        pageId,
-      });
-    }
   }
 
   toString(): string {

--- a/src/fields/cropper.ts
+++ b/src/fields/cropper.ts
@@ -1,0 +1,28 @@
+import { BaseField, FieldConstructor } from "./field";
+import { Polygon } from "../geometry";
+
+export class CropperField extends BaseField {
+  /** Straight rectangle. */
+  boundingBox: Polygon;
+  /** Free polygon with up to 30 vertices. */
+  polygon: Polygon;
+  /** Free polygon with 4 vertices. */
+  quadrangle: Polygon;
+  /** Rectangle that may be oriented (can go beyond the canvas). */
+  rectangle: Polygon;
+  /** The document page on which the information was found. */
+  pageId: number | undefined;
+
+  constructor({ prediction, valueKey = "polygon", pageId }: FieldConstructor) {
+    super({ prediction, valueKey });
+    this.pageId = pageId;
+    this.boundingBox = prediction.bounding_box;
+    this.polygon = prediction.polygon;
+    this.quadrangle = prediction.quadrangle;
+    this.rectangle = prediction.rectangle;
+  }
+
+  toString(): string {
+    return `Polygon with ${this.polygon.length} points.`;
+  }
+}

--- a/src/fields/index.ts
+++ b/src/fields/index.ts
@@ -1,11 +1,11 @@
 export { TaxField } from "./tax";
 export { PaymentDetails } from "./paymentDetails";
-export { Orientation } from "./orientation";
+export { OrientationField } from "./orientation";
 export { Locale } from "./locale";
 export { Amount } from "./amount";
 export { DateField } from "./date";
-export { BaseField } from "./field";
-export { Field } from "./field";
+export { BaseField, stringDict, Field } from "./field";
 export { ListField, ListFieldValue, ClassificationField } from "./customDocs";
 export { FullText } from "./fullText";
 export { CompanyRegistration } from "./companyRegistration";
+export { CropperField } from "./cropper";

--- a/src/fields/orientation.ts
+++ b/src/fields/orientation.ts
@@ -1,6 +1,13 @@
-import { Field } from "./field";
+import { BaseField, BaseFieldConstructor } from "./field";
 
-export class Orientation extends Field {
+interface OrientationFieldConstructor extends BaseFieldConstructor {
+  pageId: number;
+}
+
+export class OrientationField extends BaseField {
+  value: number;
+  pageId: number;
+
   /**
    * @param {Object} prediction - Prediction object from HTTP response
    * @param {String} valueKey - Key to use in the prediction dict
@@ -9,14 +16,18 @@ export class Orientation extends Field {
    */
   constructor({
     prediction,
-    valueKey = "degrees",
+    valueKey = "value",
     reconstructed = false,
     pageId,
-  }: any) {
+  }: OrientationFieldConstructor) {
+    super({ prediction, valueKey, reconstructed });
     const orientations = [0, 90, 180, 270];
-    super({ prediction, valueKey, reconstructed, pageId });
+    this.pageId = pageId;
     this.value = parseInt(prediction[valueKey]);
-    if (isNaN(this.value)) this.confidence = 0.0;
     if (!orientations.includes(this.value)) this.value = 0;
+  }
+
+  toString() {
+    return `${this.value} degrees`;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export {
   PassportResponse,
   ReceiptResponse,
   CustomResponse,
+  CropperResponse,
 } from "./api";
 export { Client } from "./client";

--- a/tests/apiPaths.ts
+++ b/tests/apiPaths.ts
@@ -1,29 +1,33 @@
-class DataPath {
-  invoice: any = {
+export const dataPath = {
+  invoice: {
     complete: "tests/data/invoice/response/complete.json",
     empty: "tests/data/invoice/response/empty.json",
     docString: "tests/data/invoice/response/doc_to_string.txt",
     page0String: "tests/data/invoice/response/page0_to_string.txt",
-  };
-  receipt: any = {
+  },
+  receipt: {
     complete: "tests/data/receipt/response/complete.json",
     empty: "tests/data/receipt/response/empty.json",
     docString: "tests/data/receipt/response/doc_to_string.txt",
     page0String: "tests/data/receipt/response/page0_to_string.txt",
-  };
-  passport: any = {
+  },
+  passport: {
     complete: "tests/data/passport/response/complete.json",
     empty: "tests/data/passport/response/empty.json",
     docString: "tests/data/passport/response/doc_to_string.txt",
     page0String: "tests/data/passport/response/page0_to_string.txt",
-  };
-  custom: any = {
+  },
+  cropperV1: {
+    complete: "tests/data/cropper/v1/response/complete.json",
+    empty: "tests/data/cropper/v1/response/empty.json",
+    docString: "tests/data/cropper/v1/response/doc_to_string.txt",
+    page0String: "tests/data/cropper/v1/response/page0_to_string.txt",
+  },
+  custom: {
     complete: "tests/data/custom/response/complete.json",
     empty: "tests/data/custom/response/empty.json",
     docString: "tests/data/custom/response/doc_to_string.txt",
     page0String: "tests/data/custom/response/page0_to_string.txt",
     page1String: "tests/data/custom/response/page1_to_string.txt",
-  };
-}
-
-export const dataPath = new DataPath();
+  },
+};

--- a/tests/documents/cropper.spec.ts
+++ b/tests/documents/cropper.spec.ts
@@ -1,62 +1,53 @@
 import { promises as fs } from "fs";
 import * as path from "path";
-import { Passport } from "../../src/documents";
+import { Cropper } from "../../src/documents";
 import { expect } from "chai";
 import { dataPath } from "../apiPaths";
 
-describe("Passport Object initialization", async () => {
+describe("Cropper Object initialization", async () => {
   it("should load an empty document prediction", async () => {
-    const jsonDataNA = await fs.readFile(path.resolve(dataPath.passport.empty));
+    const jsonDataNA = await fs.readFile(path.resolve(dataPath.cropperV1.empty));
     const response = JSON.parse(jsonDataNA.toString());
-    const doc = new Passport({
+    const doc = new Cropper({
       prediction: response.document.inference.pages[0].prediction,
     });
-    expect(doc.birthDate.value).to.be.undefined;
-    expect(doc.isExpired()).to.be.true;
-    expect(doc.surname.value).to.be.undefined;
-    expect(doc.issuanceDate.value).to.be.undefined;
-    expect(doc.expiryDate.value).to.be.undefined;
+    expect(doc.cropping.length).to.be.equals(0);
   });
 
   it("should load a complete document prediction", async () => {
     const jsonData = await fs.readFile(
-      path.resolve(dataPath.passport.complete)
+      path.resolve(dataPath.cropperV1.complete)
     );
     const response = JSON.parse(jsonData.toString());
     const prediction = response.document.inference.prediction;
-    const doc = new Passport({
+    const doc = new Cropper({
       prediction: prediction,
     });
-    const docString = await fs.readFile(path.join(dataPath.passport.docString));
+    const docString = await fs.readFile(path.join(dataPath.cropperV1.docString));
+    expect(doc.cropping.length).to.be.equals(0);
     expect(doc.toString()).to.be.equals(docString.toString());
-    expect(doc.isExpired()).to.be.false;
-
-    expect(doc.checklist["mrzValid"]).to.be.true;
-    expect(doc.checklist["mrzValidBirthDate"]).to.be.true;
-    expect(doc.checklist["mrzValidExpiryDate"]).to.be.false;
-    expect(doc.checklist["mrzValidIdNumber"]).to.be.true;
-    expect(doc.checklist["mrzValidSurname"]).to.be.true;
-    expect(doc.checklist["mrzValidCountry"]).to.be.true;
-    expect(doc.checkAll()).to.be.false;
+    expect(doc.checkAll()).to.be.true;
   });
 
   it("should load a complete page 0 prediction", async () => {
     const jsonData = await fs.readFile(
-      path.resolve(dataPath.passport.complete)
+      path.resolve(dataPath.cropperV1.complete)
     );
     const response = JSON.parse(jsonData.toString());
     const pageData = response.document.inference.pages[0];
-    const doc = new Passport({
+    const doc = new Cropper({
       prediction: pageData.prediction,
       pageId: pageData.id,
       orientation: pageData.orientation,
       extras: pageData.extras,
     });
+    console.log(doc.cropping.toString())
     const docString = await fs.readFile(
-      path.join(dataPath.passport.page0String)
+      path.join(dataPath.cropperV1.page0String)
     );
     expect(doc.orientation?.value).to.be.equals(0);
     expect(doc.toString()).to.be.equals(docString.toString());
-    expect(doc.checkAll()).to.be.false;
+    expect(doc.cropping.length).to.be.equals(2);
+    expect(doc.checkAll()).to.be.true;
   });
 });

--- a/tests/documents/customDocument.spec.ts
+++ b/tests/documents/customDocument.spec.ts
@@ -10,56 +10,63 @@ describe("Custom Document Object initialization", async () => {
       path.resolve(dataPath.custom.complete)
     );
     const response = JSON.parse(jsonDataNA.toString());
-    const custom = new CustomDocument({
-      apiPrediction: response.document.inference.prediction,
+    const doc = new CustomDocument({
+      prediction: response.document.inference.prediction,
       documentType: "field_test",
     });
-    expect(custom.documentType).to.be.equals("field_test");
-    expect(custom.fields.size).to.be.equals(10);
-    expect(custom.classifications.size).to.be.equals(1);
+    expect(doc.documentType).to.be.equals("field_test");
+    expect(doc.fields.size).to.be.equals(10);
+    expect(doc.classifications.size).to.be.equals(1);
   });
 
   it("should load a complete document prediction", async () => {
     const jsonData = await fs.readFile(path.resolve(dataPath.custom.complete));
     const response = JSON.parse(jsonData.toString());
-    const custom = new CustomDocument({
-      apiPrediction: response.document.inference.prediction,
+    const doc = new CustomDocument({
+      prediction: response.document.inference.prediction,
       documentType: "field_test",
     });
-    const stringAll = custom.fields.get("string_all");
+    const stringAll = doc.fields.get("string_all");
     expect(stringAll).to.have.property('values');
     expect(stringAll?.contentsString("-")).to.equals("Mindee-is-awesome");
     expect(stringAll?.contentsList()).to.have.members(["Mindee", "is", "awesome"]);
-    expect(custom.classifications.get("doc_type")).to.have.property('value');
-    expect(custom.fields.size).to.be.equals(10);
-    expect(custom.classifications.size).to.be.equals(1);
+    expect(doc.classifications.get("doc_type")).to.have.property('value');
+    expect(doc.fields.size).to.be.equals(10);
+    expect(doc.classifications.size).to.be.equals(1);
     const docString = await fs.readFile(path.join(dataPath.custom.docString));
-    expect(custom.toString()).to.be.equals(docString.toString());
+    expect(doc.toString()).to.be.equals(docString.toString());
   });
 
   it("should load a complete page 0 prediction", async () => {
     const jsonData = await fs.readFile(path.resolve(dataPath.custom.complete));
     const response = JSON.parse(jsonData.toString());
     const pageData = response.document.inference.pages[0];
-    const custom = new CustomDocument({
-      apiPrediction: pageData.prediction,
+    const doc = new CustomDocument({
+      prediction: pageData.prediction,
       documentType: "field_test",
       pageId: pageData.id,
+      orientation: pageData.orientation,
+      extras: pageData.extras,
     });
+    expect(doc.orientation?.value).to.be.equals(0);
+    expect(doc.cropper.length).to.be.equals(1);
     const docString = await fs.readFile(path.join(dataPath.custom.page0String));
-    expect(custom.toString()).to.be.equals(docString.toString());
+    expect(doc.toString()).to.be.equals(docString.toString());
   });
 
   it("should load a complete page 1 prediction", async () => {
     const jsonData = await fs.readFile(path.resolve(dataPath.custom.complete));
     const response = JSON.parse(jsonData.toString());
     const pageData = response.document.inference.pages[1];
-    const custom = new CustomDocument({
-      apiPrediction: pageData.prediction,
+    const doc = new CustomDocument({
+      prediction: pageData.prediction,
       documentType: "field_test",
       pageId: pageData.id,
+      orientation: pageData.orientation,
+      extras: pageData.extras,
     });
+    expect(doc.orientation?.value).to.be.equals(0);
     const docString = await fs.readFile(path.join(dataPath.custom.page1String));
-    expect(custom.toString()).to.be.equals(docString.toString());
+    expect(doc.toString()).to.be.equals(docString.toString());
   });
 });

--- a/tests/documents/financialDocument.spec.ts
+++ b/tests/documents/financialDocument.spec.ts
@@ -31,7 +31,7 @@ describe("Financial Document Object initialization", async () => {
     const jsonData = await fs.readFile(path.resolve(dataPath.invoice.complete));
     const response = JSON.parse(jsonData.toString());
     const doc = new FinancialDocument({
-      apiPrediction: response.document.inference.prediction,
+      prediction: response.document.inference.prediction,
     });
     expect((doc.date as DateField).value).to.be.equal("2020-02-17");
     expect((doc.totalTax as TaxField).value).to.be.equal(97.98);
@@ -43,7 +43,7 @@ describe("Financial Document Object initialization", async () => {
     const jsonData = await fs.readFile(path.resolve(dataPath.receipt.complete));
     const response = JSON.parse(jsonData.toString());
     const doc = new FinancialDocument({
-      apiPrediction: response.document.inference.pages[0].prediction,
+      prediction: response.document.inference.pages[0].prediction,
     });
     expect((doc.date as DateField).value).to.be.equal("2016-02-26");
     expect((doc.totalTax as TaxField).value).to.be.equal(1.7);
@@ -58,7 +58,7 @@ describe("Financial Document Object initialization", async () => {
 
   it("should initialize from a N/A receipt", async function () {
     const doc = new FinancialDocument({
-      apiPrediction: this.receiptBasePrediction,
+      prediction: this.receiptBasePrediction,
     });
     expect((doc.locale as Locale).value).to.be.undefined;
     expect((doc.totalIncl as Amount).value).to.be.undefined;
@@ -74,7 +74,7 @@ describe("Financial Document Object initialization", async () => {
 
   it("should initialize from a N/A invoice", async function () {
     const doc = new FinancialDocument({
-      apiPrediction: this.invoiceBasePrediction,
+      prediction: this.invoiceBasePrediction,
     });
     expect((doc.locale as Locale).value).to.be.undefined;
     expect((doc.totalIncl as Amount).value).to.be.undefined;

--- a/tests/documents/receipt.spec.ts
+++ b/tests/documents/receipt.spec.ts
@@ -23,7 +23,7 @@ describe("Receipt Object initialization", async () => {
     const jsonData = await fs.readFile(path.resolve(dataPath.receipt.empty));
     const response = JSON.parse(jsonData.toString());
     const doc = new Receipt({
-      apiPrediction: response.document.inference.pages[0].prediction,
+      prediction: response.document.inference.pages[0].prediction,
     });
     expect((doc.locale as Locale).value).to.be.undefined;
     expect((doc.totalIncl as Amount).value).to.be.undefined;
@@ -43,7 +43,7 @@ describe("Receipt Object initialization", async () => {
     const response = JSON.parse(jsonData.toString());
     const prediction = response.document.inference.prediction;
     const doc = new Receipt({
-      apiPrediction: prediction,
+      prediction: prediction,
     });
     const docString = await fs.readFile(path.join(dataPath.receipt.docString));
     expect(doc.toString()).to.be.equals(docString.toString());
@@ -57,18 +57,21 @@ describe("Receipt Object initialization", async () => {
     const response = JSON.parse(jsonData.toString());
     const pageData = response.document.inference.pages[0];
     const doc = new Receipt({
-      apiPrediction: pageData.prediction,
+      prediction: pageData.prediction,
       pageId: pageData.id,
+      orientation: pageData.orientation,
+      extras: pageData.extras,
     });
     const docString = await fs.readFile(
       path.join(dataPath.receipt.page0String)
     );
+    expect(doc.orientation?.value).to.be.equals(0);
     expect(doc.toString()).to.be.equals(docString.toString());
   });
 
   it("should reconstruct with N/A total", function () {
     const doc = new Receipt({
-      apiPrediction: {
+      prediction: {
         ...this.basePrediction,
         total_incl: { value: "N/A", confidence: 0.5 },
         taxes: [
@@ -82,7 +85,7 @@ describe("Receipt Object initialization", async () => {
 
   it("should reconstruct with empty taxes", function () {
     const doc = new Receipt({
-      apiPrediction: {
+      prediction: {
         ...this.basePrediction,
         total_incl: { value: 12.54, confidence: 0.5 },
         taxes: [],
@@ -93,7 +96,7 @@ describe("Receipt Object initialization", async () => {
 
   it("should reconstruct with taxes", function () {
     const doc = new Receipt({
-      apiPrediction: {
+      prediction: {
         ...this.basePrediction,
         total_incl: { value: 12.54, confidence: 0.5 },
         taxes: [

--- a/tests/fields/cropper.spec.ts
+++ b/tests/fields/cropper.spec.ts
@@ -1,0 +1,58 @@
+import { CropperField } from "../../src/fields";
+import { expect } from "chai";
+
+describe("Test Cropper field", () => {
+  it("Should create a Cropper field", () => {
+    const prediction = {
+      bounding_box: [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+      ],
+      polygon: [
+        [0.076, 0.18],
+        [0.061, 0.129],
+        [0.084, 0.131],
+        [0.035, 0.061],
+        [0.088, 0.041],
+        [0.053, 0.018],
+        [0.223, 0.021],
+        [0.365, 0.016],
+        [0.395, 0.008],
+        [0.502, 0.006],
+        [0.547, 0.014],
+        [0.602, 0.006],
+        [0.768, 0.014],
+        [0.822, 0.004],
+        [0.91, 0.004],
+        [0.994, 0.004],
+        [0.998, 0.014],
+        [0.998, 0.994],
+        [0.994, 0.998],
+        [0.006, 0.998],
+        [0.002, 0.895],
+        [0.002, 0.277],
+        [0.033, 0.246],
+        [0.006, 0.246],
+      ],
+      quadrangle: [
+        [0.001, 0.018],
+        [0.998, 0.002],
+        [0.998, 0.994],
+        [0.006, 0.998],
+      ],
+      rectangle: [
+        [-0.002, 0.006],
+        [0.996, 0],
+        [1.002, 0.992],
+        [0.004, 0.998],
+      ],
+    };
+    const field = new CropperField({prediction, pageId: 0});
+    expect(field.value).to.be.equal(field.polygon);
+    expect(field.boundingBox.length).to.be.equal(4);
+    expect(field.polygon.length).to.be.equal(24);
+    expect(field.toString()).to.be.equal("Polygon with 24 points.");
+  });
+});

--- a/tests/fields/orientation.spec.ts
+++ b/tests/fields/orientation.spec.ts
@@ -1,31 +1,28 @@
-import { Orientation } from "../../src/fields";
+import { OrientationField } from "../../src/fields";
 import { expect } from "chai";
 
 describe("Test Orientation field", () => {
   it("should create an Orientation field", () => {
     const prediction = {
-      degrees: 90,
-      probability: 0.1,
+      value: 90,
     };
-    const orientation = new Orientation({ prediction });
+    const orientation = new OrientationField({ prediction, pageId: 0 });
     expect(orientation.value).to.be.equal(90);
   });
 
   it("should create an Orientation field with an NaN value", () => {
     const prediction = {
-      degrees: "aze",
-      probability: 0.1,
+      value: "aze",
     };
-    const orientation = new Orientation({ prediction });
+    const orientation = new OrientationField({ prediction, pageId: 0 });
     expect(orientation.value).to.be.equal(0);
   });
 
   it("should create an Orientation field with an incorrect value", () => {
     const prediction = {
-      degrees: 255,
-      probability: 0.1,
+      value: 255,
     };
-    const orientation = new Orientation({ prediction });
+    const orientation = new OrientationField({ prediction, pageId: 0 });
     expect(orientation.value).to.be.equal(0);
   });
 });


### PR DESCRIPTION
Add the cropper as a stand-alone endpoint and as extra information in the predict API.

This required changing the orientation field from specific to Invoice and Receipt, to now being available for all products.

## How Has This Been Tested

Added basic unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
