### PR TITLE
:recycle: simplified syntax for predict parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,21 @@ const mindeeClient = new mindee.Client({
 // Load a file from disk
 const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
 
+// Create a custom endpoint for your product
+const customEndpoint = mindeeClient.createEndpoint(
+  "my-endpoint",
+  "my-account",
+  "my-version" // will default to 1 if not provided
+);
+
 // Parse it
 const apiResponse = mindeeClient
   .parse(
     mindee.product.CustomV1,
     inputSource,
-    "my-endpoint", 
-    "my-account",
-    "my-version" // 1 by default, but it is strongly recommended you provide it
+    {
+      endpoint: customEndpoint
+    }
   );
 ```
 
@@ -117,6 +124,53 @@ apiResponse.then((resp) => {
     // individual pages (array)
     console.log(res.document.pages);
 });
+```
+
+### Additional options
+
+#### Apply Cropping
+
+To apply the `Cropper` tool provided by Mindee, set the `croper` param to `true`:
+
+```js
+//...
+const apiResponse = mindeeClient.parse(
+  mindee.product.InvoiceV4,
+  inputSource,
+  { cropper: true }
+);
+```
+
+#### Full-Text extraction (OCR)
+
+To extract all words read on your document, set the `fullText` param to `true`:
+
+```js
+//...
+const apiResponse = mindeeClient.parse(
+  mindee.product.InvoiceV4,
+  inputSource,
+  { fullText: true }
+);
+```
+> Note: this parameter is only available on the InvoiceV4, ReceiptV5 & FinancialDocumentV1 APIs for now.
+
+#### Page options
+
+Here's an example on how to apply page options:
+
+```js
+//...
+const apiResponse = mindeeClient.parse(
+  mindee.product.InvoiceV4,
+  inputSource,
+  {
+    pageOptions: {
+      pageIndexes=[0, 1, 2, 3],
+      operation: mindee.PageOptionsOperation.KeepOnly,
+      onMinPages: 2
+    }
+  });
 ```
 
 ## Further Reading

--- a/docs/code_samples/custom_v1.txt
+++ b/docs/code_samples/custom_v1.txt
@@ -10,13 +10,21 @@ const mindeeClient = new mindee.Client({
 // Load a file from disk
 const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
 
+// Create a custom endpoint for your product
+const customEndpoint = mindeeClient.createEndpoint(
+  "my-endpoint",
+  "my-account"
+)
+
 // Parse it
 const apiResponse = mindeeClient
   .parse(
     mindee.product.CustomV1,
     inputSource,
-    "my-endpoint", 
-    "my-account"
+    {
+      endpoint: customEndpoint,
+      cropper: true
+    }
   );
 
 // Handle the response Promise

--- a/docs/code_samples/custom_v1.txt
+++ b/docs/code_samples/custom_v1.txt
@@ -14,7 +14,7 @@ const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
 const customEndpoint = mindeeClient.createEndpoint(
   "my-endpoint",
   "my-account"
-)
+);
 
 // Parse it
 const apiResponse = mindeeClient

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,24 +182,26 @@ async function callParse(command: string, inputPath: string, options: any) {
   const predictParams = getPredictParams(options);
   const pageOptions = getPageOptions(options);
   const inputSource = mindeeClient.docFromPath(inputPath);
-  const response = COMMAND_CUSTOM
-    ? await mindeeClient.parse(
-        conf.docClass,
-        inputSource,
-        undefined,
-        undefined,
-        undefined,
-        predictParams
-      )
-    : await mindeeClient.parse(
-        conf.docClass,
-        inputSource,
-        options.documentType,
-        options.user,
-        options.version,
-        predictParams,
-        pageOptions
-      );
+  let response;
+  if (COMMAND_CUSTOM) {
+    const customEndpoint = mindeeClient.createEndpoint(
+      options.endpoint,
+      options.account,
+      options.version
+    );
+    response = await mindeeClient.parse(conf.docClass, inputSource, {
+      endpoint: customEndpoint,
+      pageOptions: pageOptions,
+      fullText: predictParams.fullText,
+      cropper: predictParams.cropper,
+    });
+  } else {
+    response = await mindeeClient.parse(conf.docClass, inputSource, {
+      pageOptions: pageOptions,
+      fullText: predictParams.fullText,
+      cropper: predictParams.cropper,
+    });
+  }
   printResponse(response.document, options);
 }
 
@@ -209,15 +211,27 @@ async function callEnqueue(command: string, inputPath: string, options: any) {
   const predictParams = getPredictParams(options);
   const pageOptions = getPageOptions(options);
   const inputSource = mindeeClient.docFromPath(inputPath);
-  const response = await mindeeClient.enqueue(
-    conf.docClass,
-    inputSource,
-    options.documentType,
-    options.user,
-    options.version,
-    predictParams,
-    pageOptions
-  );
+
+  let response;
+  if (COMMAND_CUSTOM) {
+    const customEndpoint = mindeeClient.createEndpoint(
+      options.endpoint,
+      options.account,
+      options.version
+    );
+    response = await mindeeClient.enqueue(conf.docClass, inputSource, {
+      endpoint: customEndpoint,
+      pageOptions: pageOptions,
+      fullText: predictParams.fullText,
+      cropper: predictParams.cropper,
+    });
+  } else {
+    response = await mindeeClient.enqueue(conf.docClass, inputSource, {
+      pageOptions: pageOptions,
+      fullText: predictParams.fullText,
+      cropper: predictParams.cropper,
+    });
+  }
   console.log(response.job);
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- :arrow_up: moved all variables except product type and input into a `params` object to simplify syntax
- :sparkles: added option to create custom endpoint before parsing
- :recycle: tweaked cli to match those changes

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires a change to the official Guide documentation.
