### PR TITLE
:construction_worker: don't install the latest version of npm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,7 @@ jobs:
           cache: "npm"
 
       - name: Install Node.js dependencies
-        run: |
-          npm install npm@latest -g
-          npm ci
+        run: npm ci
 
       - name: Compilation
         run: npm run build


### PR DESCRIPTION
## Description
Looks like installing the latest npm version breaks things on node 16 now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
