### PR TITLE
:bug: take line height tolerance into account when evaluating fields

### DIFF
--- a/src/parsing/custom/index.ts
+++ b/src/parsing/custom/index.ts
@@ -1,3 +1,3 @@
-export { CustomLine, getLineItems } from "./lineItems";
+export { CustomLine, CustomLines, getLineItems } from "./lineItems";
 export { ClassificationField } from "./classificationField";
 export { ListField, ListFieldValue } from "./listField";

--- a/src/product/custom/customV1Document.ts
+++ b/src/product/custom/customV1Document.ts
@@ -1,6 +1,6 @@
 import { cleanOutString } from "../../parsing/common";
 import { StringDict, Prediction } from "../../parsing/common";
-import {ClassificationField, ListField, getLineItems, CustomLine } from "../../parsing/custom";
+import { ClassificationField, ListField, getLineItems, CustomLines } from "../../parsing/custom";
 
 /**
  * Document data for Custom builds.
@@ -56,7 +56,7 @@ export class CustomV1Document implements Prediction {
    * @param fieldNames list of all column fields.
    * @param heightTolerance height tolerance to apply to lines.
    */
-  columnsToLineItems(anchorNames: string[], fieldNames: string[], heightTolerance: number = 0.01): CustomLine[] {
+  columnsToLineItems(anchorNames: string[], fieldNames: string[], heightTolerance: number = 0.01): CustomLines {
     return getLineItems(
       anchorNames,
       fieldNames,

--- a/src/product/custom/customV1Page.ts
+++ b/src/product/custom/customV1Page.ts
@@ -1,6 +1,6 @@
 import { cleanOutString } from "../../parsing/common";
 import { StringDict, Prediction } from "../../parsing/common";
-import { ListField, CustomLine, getLineItems } from "../../parsing/custom";
+import { ListField, CustomLines, getLineItems } from "../../parsing/custom";
 
 /**
  * Page data for Custom builds.
@@ -29,7 +29,7 @@ export class CustomV1Page implements Prediction {
    * @param fieldNames list of all column fields.
    * @param heightTolerance height tolerance to apply to lines.
    */
-  columnsToLineItems(anchorNames: string[], fieldNames: string[], heightTolerance: number = 0.01): CustomLine[] {
+  columnsToLineItems(anchorNames: string[], fieldNames: string[], heightTolerance: number = 0.01): CustomLines {
     return getLineItems(
       anchorNames,
       fieldNames,


### PR DESCRIPTION
## Description
Make sure to use the line tolerance when calculating fields, otherwise some fields are omitted.


## How Has This Been Tested
When writing the tutorial.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
