### PR TITLE
:bug: fix page id syntax to account for newer syntax

### DIFF
--- a/src/parsing/custom/listField.ts
+++ b/src/parsing/custom/listField.ts
@@ -44,7 +44,7 @@ export class ListField {
   /** True if the field was reconstructed or computed using other fields. */
   reconstructed: boolean;
   /** The document page on which the information was found. */
-  pageId: number;
+  pageId?: number;
 
   /**
    * @param {BaseFieldConstructor} constructor Constructor parameters.
@@ -57,10 +57,17 @@ export class ListField {
     this.values = [];
     this.confidence = prediction["confidence"];
     this.reconstructed = reconstructed;
-    this.pageId = pageId !== undefined ? pageId : prediction["page_id"];
+    if (prediction["page_id"]) {
+      this.pageId = pageId !== undefined ? pageId : prediction["page_id"];
+    } else {
+      this.pageId = undefined;
+    }
 
     if (prediction["values"] !== undefined) {
       prediction["values"].forEach((field: StringDict) => {
+        if (field["page_id"] && field["page_id"] !== null) {
+          this.pageId = field["page_id"];
+        }
         this.values.push(new ListFieldValue(field));
       });
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :bug: current version of custom build has changed the `page_id` position for candidates, causing CustomV1 product to lose the property per field. This fixes it.
* :recycle: marked page_id as optional to account for this change

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
