### PR TITLE
:recycle: deprecate old error handler

### DIFF
--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -2,6 +2,7 @@ import { logger } from "../logger";
 
 /**
  * Custom Error handling class.
+ * @deprecated Clashes with current implementation of some errors, which may cause unexpected behaviors.
  */
 export class ErrorHandler {
   public throwOnError: boolean;

--- a/src/input/sources.ts
+++ b/src/input/sources.ts
@@ -2,7 +2,6 @@ import { promises as fs } from "fs";
 import { Readable } from "stream";
 import * as path from "path";
 
-import { errorHandler } from "../errors/handler";
 import { Buffer } from "buffer";
 import { logger } from "../logger";
 import {
@@ -150,7 +149,7 @@ export class UrlInput extends InputSource {
 
   async init() {
     if (!this.url.toLowerCase().startsWith("https")) {
-      errorHandler.throw(new Error("URL must be HTTPS"));
+      throw new Error("URL must be HTTPS");
     }
     this.fileObject = this.url;
   }

--- a/src/parsing/generated/generatedObject.ts
+++ b/src/parsing/generated/generatedObject.ts
@@ -60,7 +60,7 @@ export class GeneratedObjectField {
   /**
    * Formats a float number to have at least one decimal place.
    * @param n Input number.
-   * @returns 
+   * @returns
    */
   private toNumberString(n: number): string {
     if (Number.isInteger(n)) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :black_flag: marked the `errorHandler` class as deprecated
* :recycle: tweaked url error handling to prevent them from being sent to the server.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#265 


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
