### PR TITLE
:sparkles: add support for local responses, webhooks & HMAC signature

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,7 +25,7 @@ import { CustomV1 } from "./product";
 import {
   setTimeout,
 } from "node:timers/promises";
-import {MindeeError} from "./errors";
+import { MindeeError } from "./errors";
 
 /**
  * Options relating to predictions.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,6 @@ export {
   Document,
   Page,
 } from "./parsing/common";
-export { InputSource, PageOptionsOperation } from "./input";
+export { InputSource, PageOptionsOperation, LocalResponse } from "./input";
 export * as internal from "./internal";
 export * as imageOperations from "./imageOperations";

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -15,3 +15,4 @@ export {
   INPUT_TYPE_STREAM,
   INPUT_TYPE_BUFFER,
 } from "./base";
+export { LocalResponse } from "./localResponse"

--- a/src/input/localResponse.ts
+++ b/src/input/localResponse.ts
@@ -1,0 +1,81 @@
+import * as crypto from "crypto";
+import * as fs from "node:fs/promises";
+import { StringDict } from "../parsing/common";
+import { MindeeError } from "../errors";
+import { Buffer } from "buffer";
+
+/**
+ * Local response loaded from a file.
+ */
+export class LocalResponse {
+  private file: Buffer;
+  private readonly inputHandle: Buffer | string;
+
+  /**
+   * Creates an instance of LocalResponse.
+   */
+  constructor(inputFile: Buffer | string) {
+    this.file = Buffer.alloc(0);
+    this.inputHandle = inputFile;
+  }
+
+  public async init() {
+    /**
+     * @param inputFile - The input file, which can be a Buffer, string, or PathLike.
+     */
+    if (Buffer.isBuffer(this.inputHandle)) {
+      this.file = this.inputHandle;
+    } else if (typeof this.inputHandle === "string") {
+      let fileContents;
+      try {
+        await fs.access(this.inputHandle);
+        fileContents = await fs.readFile(this.inputHandle, { encoding: "utf-8" });
+      } catch {
+        fileContents = this.inputHandle;
+      }
+      this.file = Buffer.from(fileContents.replace(/\r/g, "").replace(/\n/g, ""), "utf-8");
+    } else {
+      throw new MindeeError("Incompatible type for input.");
+    }
+  }
+
+  /**
+   * Returns the dictionary representation of the file.
+   * @returns A JSON-like object.
+   */
+  asDict(): StringDict {
+    try {
+      const content = this.file.toString("utf-8");
+      return JSON.parse(content);
+    } catch (error) {
+      throw new MindeeError("File is not a valid dictionary.");
+    }
+  }
+
+  /**
+   * Returns the HMAC signature of the local response, from the secret key provided.
+   * @param secretKey - Secret key, either a string or a byte/byte array.
+   * @returns The HMAC signature of the local response.
+   */
+  getHmacSignature(secretKey: string | Buffer | Uint8Array): string {
+    const algorithm = "sha256";
+    try {
+      const hmac = crypto.createHmac(algorithm, secretKey);
+      hmac.update(this.file);
+      return hmac.digest("hex");
+    } catch (error) {
+      throw new MindeeError("Could not get HMAC signature from payload.");
+    }
+  }
+
+  /**
+   * Checks if the HMAC signature of the local response is valid.
+   * @param secretKey - Secret key, either a string or a byte/byte array.
+   * @param signature - The signature to be compared with.
+   * @returns True if the HMAC signature is valid.
+   */
+  isValidHmacSignature(secretKey: string | Buffer | Uint8Array, signature: string): boolean {
+    return signature === this.getHmacSignature(secretKey);
+  }
+
+}

--- a/tests/inputs/localResponse.spec.ts
+++ b/tests/inputs/localResponse.spec.ts
@@ -1,0 +1,45 @@
+import {
+  PathInput,
+  PageOptionsOperation,
+  INPUT_TYPE_PATH, LocalResponse,
+} from "../../src/input";
+import * as fs from "node:fs/promises";
+import * as path from "path";
+import { expect } from "chai";
+
+const signature: string = "5ed1673e34421217a5dbfcad905ee62261a3dd66c442f3edd19302072bbf70d0";
+const dummySecretKey: string = "ogNjY44MhvKPGTtVsI8zG82JqWQa68woYQH";
+const filePath: string = "tests/data/async/get_completed_empty.json";
+
+
+describe("A valid local response", () => {
+  it("should load a string properly.", async () => {
+    const fileObj = await fs.readFile(filePath, {encoding: "utf-8"})
+    const localResponse = new LocalResponse(fileObj);
+    await localResponse.init();
+    expect(localResponse.asDict()).to.not.be.null;
+    expect(localResponse.isValidHmacSignature(dummySecretKey, "invalid signature")).to.be.false;
+    expect(localResponse.getHmacSignature(dummySecretKey)).to.eq(signature);
+    expect(localResponse.isValidHmacSignature(dummySecretKey, signature)).to.be.true;
+  });
+
+  it('should load a file properly.', async () => {
+    const localResponse = new LocalResponse(filePath);
+    await localResponse.init();
+    expect(localResponse.asDict()).to.not.be.null;
+    expect(localResponse.isValidHmacSignature(dummySecretKey, "invalid signature")).to.be.false;
+    expect(localResponse.getHmacSignature(dummySecretKey)).to.eq(signature);
+    expect(localResponse.isValidHmacSignature(dummySecretKey, signature)).to.be.true;
+  });
+
+  it('should load a file properly.', async () => {
+    const fileStr = (await fs.readFile(filePath, {encoding: "utf-8"})).replace(/\r/g, "").replace(/\n/g, "");
+    const fileBuffer = Buffer.from(fileStr, "utf-8");
+    const localResponse = new LocalResponse(fileBuffer);
+    await localResponse.init();
+    expect(localResponse.asDict()).to.not.be.null;
+    expect(localResponse.isValidHmacSignature(dummySecretKey, "invalid signature")).to.be.false;
+    expect(localResponse.getHmacSignature(dummySecretKey)).to.eq(signature);
+    expect(localResponse.isValidHmacSignature(dummySecretKey, signature)).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :sparkles: add support for local response loading
* :sparkles: add support for HMAC validation (for webhooks)

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
