### PR TITLE
:bug: fix page operations not taking minimum threshold into account

### DIFF
--- a/tests/pdf/pdfOperation.spec.ts
+++ b/tests/pdf/pdfOperation.spec.ts
@@ -117,7 +117,7 @@ describe("Test pdf operation", () => {
     await inputDoc.init();
 
     const pageOptions: PageOptions = {
-      pageIndexes: [0],
+      pageIndexes: [0, 1, 3, 4],
       operation: PageOptionsOperation.KeepOnly,
       onMinPages: 12,
     };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
* :bug: fix onMinPages threshold ignored when page operations are longer than the file pages
* :recycle: fix test that was supposed to test for this

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#296

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
