### PR TITLE
:sparkles: add support for USMailV2, BillOfLadingV1, FR EnergyBillV1, FR Payslip V1 & NutritionFactsLabel V1

### DIFF
--- a/docs/bill_of_lading_v1.md
+++ b/docs/bill_of_lading_v1.md
@@ -1,0 +1,205 @@
+---
+title: Bill of Lading OCR Node.js
+category: 622b805aaec68102ea7fcbc2
+slug: nodejs-bill-of-lading-ocr
+parentDoc: 609809574212d40077a040f1
+---
+The Node.js OCR SDK supports the [Bill of Lading API](https://platform.mindee.com/mindee/bill_of_lading).
+
+The [sample below](https://github.com/mindee/client-lib-test-data/blob/main/products/bill_of_lading/default_sample.jpg) can be used for testing purposes.
+![Bill of Lading sample](https://github.com/mindee/client-lib-test-data/blob/main/products/bill_of_lading/default_sample.jpg?raw=true)
+
+# Quick-Start
+```js
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.BillOfLadingV1,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});
+```
+# Field Types
+## Standard Fields
+These fields are generic and used in several products.
+
+### Basic Field
+Each prediction object contains a set of fields that inherit from the generic `Field` class.
+A typical `Field` object will have the following attributes:
+
+* **value** (`number | string`): corresponds to the field value. Can be `undefined` if no value was extracted.
+* **confidence** (`number`): the confidence score of the field prediction.
+* **boundingBox** (`[Point, Point, Point, Point]`): contains exactly 4 relative vertices (points) coordinates of a right rectangle containing the field in the document.
+* **polygon** (`Point[]`): contains the relative vertices coordinates (`Point`) of a polygon containing the field in the image.
+* **pageId** (`number`): the ID of the page, always `undefined` when at document-level.
+* **reconstructed** (`boolean`): indicates whether an object was reconstructed (not extracted as the API gave it).
+
+> **Note:** A `Point` simply refers to an array of two numbers (`[number, number]`).
+
+
+Aside from the previous attributes, all basic fields have access to a `toString()` method that can be used to print their value as a string.
+
+### Date Field
+Aside from the basic `Field` attributes, the date field `DateField` also implements the following: 
+
+* **dateObject** (`Date`): an accessible representation of the value as a JavaScript object.
+
+### String Field
+The text field `StringField` only has one constraint: its **value** is a `string` (or `undefined`).
+
+## Specific Fields
+Fields which are specific to this product; they are not used in any other product.
+
+### Carrier Field
+The shipping company responsible for transporting the goods.
+
+A `BillOfLadingV1Carrier` implements the following attributes:
+
+* `name` (string): The name of the carrier.
+* `professionalNumber` (string): The professional number of the carrier.
+* `scac` (string): The Standard Carrier Alpha Code (SCAC) of the carrier.
+Fields which are specific to this product; they are not used in any other product.
+
+### Consignee Field
+The party to whom the goods are being shipped.
+
+A `BillOfLadingV1Consignee` implements the following attributes:
+
+* `address` (string): The address of the consignee.
+* `email` (string): The  email of the shipper.
+* `name` (string): The name of the consignee.
+* `phone` (string): The phone number of the consignee.
+Fields which are specific to this product; they are not used in any other product.
+
+### Items Field
+The goods being shipped.
+
+A `BillOfLadingV1CarrierItem` implements the following attributes:
+
+* `description` (string): A description of the item.
+* `grossWeight` (number): The gross weight of the item.
+* `measurement` (number): The measurement of the item.
+* `measurementUnit` (string): The unit of measurement for the measurement.
+* `quantity` (number): The quantity of the item being shipped.
+* `weightUnit` (string): The unit of measurement for weights.
+Fields which are specific to this product; they are not used in any other product.
+
+### Notify Party Field
+The party to be notified of the arrival of the goods.
+
+A `BillOfLadingV1NotifyParty` implements the following attributes:
+
+* `address` (string): The address of the notify party.
+* `email` (string): The  email of the shipper.
+* `name` (string): The name of the notify party.
+* `phone` (string): The phone number of the notify party.
+Fields which are specific to this product; they are not used in any other product.
+
+### Shipper Field
+The party responsible for shipping the goods.
+
+A `BillOfLadingV1Shipper` implements the following attributes:
+
+* `address` (string): The address of the shipper.
+* `email` (string): The  email of the shipper.
+* `name` (string): The name of the shipper.
+* `phone` (string): The phone number of the shipper.
+
+# Attributes
+The following fields are extracted for Bill of Lading V1:
+
+## Bill of Lading Number
+**billOfLadingNumber** ([StringField](#string-field)): A unique identifier assigned to a Bill of Lading document.
+
+```js
+console.log(result.document.inference.prediction.billOfLadingNumber.value);
+```
+
+## Carrier
+**carrier** ([BillOfLadingV1Carrier](#carrier-field)): The shipping company responsible for transporting the goods.
+
+```js
+console.log(result.document.inference.prediction.carrier.value);
+```
+
+## Items
+**carrierItems** ([BillOfLadingV1CarrierItem](#items-field)[]): The goods being shipped.
+
+```js
+for (const carrierItemsElem of result.document.inference.prediction.carrierItems) {
+  console.log(carrierItemsElem.value);
+}
+```
+
+## Consignee
+**consignee** ([BillOfLadingV1Consignee](#consignee-field)): The party to whom the goods are being shipped.
+
+```js
+console.log(result.document.inference.prediction.consignee.value);
+```
+
+## Date of issue
+**dateOfIssue** ([DateField](#date-field)): The date when the bill of lading is issued.
+
+```js
+console.log(result.document.inference.prediction.dateOfIssue.value);
+```
+
+## Departure Date
+**departureDate** ([DateField](#date-field)): The date when the vessel departs from the port of loading.
+
+```js
+console.log(result.document.inference.prediction.departureDate.value);
+```
+
+## Notify Party
+**notifyParty** ([BillOfLadingV1NotifyParty](#notify-party-field)): The party to be notified of the arrival of the goods.
+
+```js
+console.log(result.document.inference.prediction.notifyParty.value);
+```
+
+## Place of Delivery
+**placeOfDelivery** ([StringField](#string-field)): The place where the goods are to be delivered.
+
+```js
+console.log(result.document.inference.prediction.placeOfDelivery.value);
+```
+
+## Port of Discharge
+**portOfDischarge** ([StringField](#string-field)): The port where the goods are unloaded from the vessel.
+
+```js
+console.log(result.document.inference.prediction.portOfDischarge.value);
+```
+
+## Port of Loading
+**portOfLoading** ([StringField](#string-field)): The port where the goods are loaded onto the vessel.
+
+```js
+console.log(result.document.inference.prediction.portOfLoading.value);
+```
+
+## Shipper
+**shipper** ([BillOfLadingV1Shipper](#shipper-field)): The party responsible for shipping the goods.
+
+```js
+console.log(result.document.inference.prediction.shipper.value);
+```
+
+# Questions?
+[Join our Slack](https://join.slack.com/t/mindee-community/shared_invite/zt-2d0ds7dtz-DPAF81ZqTy20chsYpQBW5g)

--- a/docs/code_samples/bill_of_lading_v1_async.txt
+++ b/docs/code_samples/bill_of_lading_v1_async.txt
@@ -1,0 +1,21 @@
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.BillOfLadingV1,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});

--- a/docs/code_samples/energy_bill_fra_v1_async.txt
+++ b/docs/code_samples/energy_bill_fra_v1_async.txt
@@ -1,0 +1,21 @@
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.fr.EnergyBillV1,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});

--- a/docs/code_samples/nutrition_facts_v1_async.txt
+++ b/docs/code_samples/nutrition_facts_v1_async.txt
@@ -1,0 +1,21 @@
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.NutritionFactsLabelV1,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});

--- a/docs/code_samples/payslip_fra_v2_async.txt
+++ b/docs/code_samples/payslip_fra_v2_async.txt
@@ -1,0 +1,21 @@
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.fr.PayslipV2,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});

--- a/docs/code_samples/us_mail_v2_async.txt
+++ b/docs/code_samples/us_mail_v2_async.txt
@@ -1,0 +1,21 @@
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.us.UsMailV2,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});

--- a/docs/energy_bill_fra_v1.md
+++ b/docs/energy_bill_fra_v1.md
@@ -1,0 +1,252 @@
+---
+title: FR Energy Bill OCR Node.js
+category: 622b805aaec68102ea7fcbc2
+slug: nodejs-fr-energy-bill-ocr
+parentDoc: 609809574212d40077a040f1
+---
+The Node.js OCR SDK supports the [Energy Bill API](https://platform.mindee.com/mindee/energy_bill_fra).
+
+The [sample below](https://github.com/mindee/client-lib-test-data/blob/main/products/energy_bill_fra/default_sample.jpg) can be used for testing purposes.
+![Energy Bill sample](https://github.com/mindee/client-lib-test-data/blob/main/products/energy_bill_fra/default_sample.jpg?raw=true)
+
+# Quick-Start
+```js
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.fr.EnergyBillV1,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});
+```
+# Field Types
+## Standard Fields
+These fields are generic and used in several products.
+
+### Basic Field
+Each prediction object contains a set of fields that inherit from the generic `Field` class.
+A typical `Field` object will have the following attributes:
+
+* **value** (`number | string`): corresponds to the field value. Can be `undefined` if no value was extracted.
+* **confidence** (`number`): the confidence score of the field prediction.
+* **boundingBox** (`[Point, Point, Point, Point]`): contains exactly 4 relative vertices (points) coordinates of a right rectangle containing the field in the document.
+* **polygon** (`Point[]`): contains the relative vertices coordinates (`Point`) of a polygon containing the field in the image.
+* **pageId** (`number`): the ID of the page, always `undefined` when at document-level.
+* **reconstructed** (`boolean`): indicates whether an object was reconstructed (not extracted as the API gave it).
+
+> **Note:** A `Point` simply refers to an array of two numbers (`[number, number]`).
+
+
+Aside from the previous attributes, all basic fields have access to a `toString()` method that can be used to print their value as a string.
+
+
+### Amount Field
+The amount field `AmountField` only has one constraint: its **value** is a `number` (or `undefined`).
+
+### Date Field
+Aside from the basic `Field` attributes, the date field `DateField` also implements the following: 
+
+* **dateObject** (`Date`): an accessible representation of the value as a JavaScript object.
+
+### String Field
+The text field `StringField` only has one constraint: its **value** is a `string` (or `undefined`).
+
+## Specific Fields
+Fields which are specific to this product; they are not used in any other product.
+
+### Energy Consumer Field
+The entity that consumes the energy.
+
+A `EnergyBillV1EnergyConsumer` implements the following attributes:
+
+* `address` (string): The address of the energy consumer.
+* `name` (string): The name of the energy consumer.
+Fields which are specific to this product; they are not used in any other product.
+
+### Energy Supplier Field
+The company that supplies the energy.
+
+A `EnergyBillV1EnergySupplier` implements the following attributes:
+
+* `address` (string): The address of the energy supplier.
+* `name` (string): The name of the energy supplier.
+Fields which are specific to this product; they are not used in any other product.
+
+### Energy Usage Field
+Details of energy consumption.
+
+A `EnergyBillV1EnergyUsage` implements the following attributes:
+
+* `description` (string): Description or details of the energy usage.
+* `endDate` (string): The end date of the energy usage.
+* `startDate` (string): The start date of the energy usage.
+* `taxRate` (number): The rate of tax applied to the total cost.
+* `total` (number): The total cost of energy consumed.
+* `unitPrice` (number): The price per unit of energy consumed.
+Fields which are specific to this product; they are not used in any other product.
+
+### Meter Details Field
+Information about the energy meter.
+
+A `EnergyBillV1MeterDetail` implements the following attributes:
+
+* `meterNumber` (string): The unique identifier of the energy meter.
+* `meterType` (string): The type of energy meter.
+
+#### Possible values include:
+ - electricity
+ - gas
+ - water
+ - None
+
+* `unit` (string): The unit of measurement for energy consumption, which can be kW, m³, or L.
+Fields which are specific to this product; they are not used in any other product.
+
+### Subscription Field
+The subscription details fee for the energy service.
+
+A `EnergyBillV1Subscription` implements the following attributes:
+
+* `description` (string): Description or details of the subscription.
+* `endDate` (string): The end date of the subscription.
+* `startDate` (string): The start date of the subscription.
+* `taxRate` (number): The rate of tax applied to the total cost.
+* `total` (number): The total cost of subscription.
+* `unitPrice` (number): The price per unit of subscription.
+Fields which are specific to this product; they are not used in any other product.
+
+### Taxes and Contributions Field
+Details of Taxes and Contributions.
+
+A `EnergyBillV1TaxesAndContribution` implements the following attributes:
+
+* `description` (string): Description or details of the Taxes and Contributions.
+* `endDate` (string): The end date of the Taxes and Contributions.
+* `startDate` (string): The start date of the Taxes and Contributions.
+* `taxRate` (number): The rate of tax applied to the total cost.
+* `total` (number): The total cost of Taxes and Contributions.
+* `unitPrice` (number): The price per unit of Taxes and Contributions.
+
+# Attributes
+The following fields are extracted for Energy Bill V1:
+
+## Contract ID
+**contractId** ([StringField](#string-field)): The unique identifier associated with a specific contract.
+
+```js
+console.log(result.document.inference.prediction.contractId.value);
+```
+
+## Delivery Point
+**deliveryPoint** ([StringField](#string-field)): The unique identifier assigned to each electricity or gas consumption point. It specifies the exact location where the energy is delivered.
+
+```js
+console.log(result.document.inference.prediction.deliveryPoint.value);
+```
+
+## Due Date
+**dueDate** ([DateField](#date-field)): The date by which the payment for the energy invoice is due.
+
+```js
+console.log(result.document.inference.prediction.dueDate.value);
+```
+
+## Energy Consumer
+**energyConsumer** ([EnergyBillV1EnergyConsumer](#energy-consumer-field)): The entity that consumes the energy.
+
+```js
+console.log(result.document.inference.prediction.energyConsumer.value);
+```
+
+## Energy Supplier
+**energySupplier** ([EnergyBillV1EnergySupplier](#energy-supplier-field)): The company that supplies the energy.
+
+```js
+console.log(result.document.inference.prediction.energySupplier.value);
+```
+
+## Energy Usage
+**energyUsage** ([EnergyBillV1EnergyUsage](#energy-usage-field)[]): Details of energy consumption.
+
+```js
+for (const energyUsageElem of result.document.inference.prediction.energyUsage) {
+  console.log(energyUsageElem.value);
+}
+```
+
+## Invoice Date
+**invoiceDate** ([DateField](#date-field)): The date when the energy invoice was issued.
+
+```js
+console.log(result.document.inference.prediction.invoiceDate.value);
+```
+
+## Invoice Number
+**invoiceNumber** ([StringField](#string-field)): The unique identifier of the energy invoice.
+
+```js
+console.log(result.document.inference.prediction.invoiceNumber.value);
+```
+
+## Meter Details
+**meterDetails** ([EnergyBillV1MeterDetail](#meter-details-field)): Information about the energy meter.
+
+```js
+console.log(result.document.inference.prediction.meterDetails.value);
+```
+
+## Subscription
+**subscription** ([EnergyBillV1Subscription](#subscription-field)[]): The subscription details fee for the energy service.
+
+```js
+for (const subscriptionElem of result.document.inference.prediction.subscription) {
+  console.log(subscriptionElem.value);
+}
+```
+
+## Taxes and Contributions
+**taxesAndContributions** ([EnergyBillV1TaxesAndContribution](#taxes-and-contributions-field)[]): Details of Taxes and Contributions.
+
+```js
+for (const taxesAndContributionsElem of result.document.inference.prediction.taxesAndContributions) {
+  console.log(taxesAndContributionsElem.value);
+}
+```
+
+## Total Amount
+**totalAmount** ([AmountField](#amount-field)): The total amount to be paid for the energy invoice.
+
+```js
+console.log(result.document.inference.prediction.totalAmount.value);
+```
+
+## Total Before Taxes
+**totalBeforeTaxes** ([AmountField](#amount-field)): The total amount to be paid for the energy invoice before taxes.
+
+```js
+console.log(result.document.inference.prediction.totalBeforeTaxes.value);
+```
+
+## Total Taxes
+**totalTaxes** ([AmountField](#amount-field)): Total of taxes applied to the invoice.
+
+```js
+console.log(result.document.inference.prediction.totalTaxes.value);
+```
+
+# Questions?
+[Join our Slack](https://join.slack.com/t/mindee-community/shared_invite/zt-2d0ds7dtz-DPAF81ZqTy20chsYpQBW5g)

--- a/docs/energy_bill_fra_v1.md
+++ b/docs/energy_bill_fra_v1.md
@@ -111,7 +111,7 @@ A `EnergyBillV1MeterDetail` implements the following attributes:
  - electricity
  - gas
  - water
- - None
+ - `null`
 
 * `unit` (string): The unit of measurement for energy consumption, which can be kW, m³, or L.
 Fields which are specific to this product; they are not used in any other product.

--- a/docs/nutrition_facts_v1.md
+++ b/docs/nutrition_facts_v1.md
@@ -1,0 +1,298 @@
+---
+title: Nutrition Facts Label OCR Node.js
+category: 622b805aaec68102ea7fcbc2
+slug: nodejs-nutrition-facts-label-ocr
+parentDoc: 609809574212d40077a040f1
+---
+The Node.js OCR SDK supports the [Nutrition Facts Label API](https://platform.mindee.com/mindee/nutrition_facts).
+
+The [sample below](https://github.com/mindee/client-lib-test-data/blob/main/products/nutrition_facts/default_sample.jpg) can be used for testing purposes.
+![Nutrition Facts Label sample](https://github.com/mindee/client-lib-test-data/blob/main/products/nutrition_facts/default_sample.jpg?raw=true)
+
+# Quick-Start
+```js
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.NutritionFactsLabelV1,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});
+```
+# Field Types
+## Standard Fields
+These fields are generic and used in several products.
+
+### Basic Field
+Each prediction object contains a set of fields that inherit from the generic `Field` class.
+A typical `Field` object will have the following attributes:
+
+* **value** (`number | string`): corresponds to the field value. Can be `undefined` if no value was extracted.
+* **confidence** (`number`): the confidence score of the field prediction.
+* **boundingBox** (`[Point, Point, Point, Point]`): contains exactly 4 relative vertices (points) coordinates of a right rectangle containing the field in the document.
+* **polygon** (`Point[]`): contains the relative vertices coordinates (`Point`) of a polygon containing the field in the image.
+* **pageId** (`number`): the ID of the page, always `undefined` when at document-level.
+* **reconstructed** (`boolean`): indicates whether an object was reconstructed (not extracted as the API gave it).
+
+> **Note:** A `Point` simply refers to an array of two numbers (`[number, number]`).
+
+
+Aside from the previous attributes, all basic fields have access to a `toString()` method that can be used to print their value as a string.
+
+
+### Amount Field
+The amount field `AmountField` only has one constraint: its **value** is a `number` (or `undefined`).
+
+## Specific Fields
+Fields which are specific to this product; they are not used in any other product.
+
+### Added Sugars Field
+The amount of added sugars in the product.
+
+A `NutritionFactsLabelV1AddedSugar` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of added sugars to consume or not to exceed each day.
+* `per100G` (number): The amount of added sugars per 100g of the product.
+* `perServing` (number): The amount of added sugars per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Calories Field
+The amount of calories in the product.
+
+A `NutritionFactsLabelV1Calorie` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of calories to consume or not to exceed each day.
+* `per100G` (number): The amount of calories per 100g of the product.
+* `perServing` (number): The amount of calories per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Cholesterol Field
+The amount of cholesterol in the product.
+
+A `NutritionFactsLabelV1Cholesterol` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of cholesterol to consume or not to exceed each day.
+* `per100G` (number): The amount of cholesterol per 100g of the product.
+* `perServing` (number): The amount of cholesterol per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Dietary Fiber Field
+The amount of dietary fiber in the product.
+
+A `NutritionFactsLabelV1DietaryFiber` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of dietary fiber to consume or not to exceed each day.
+* `per100G` (number): The amount of dietary fiber per 100g of the product.
+* `perServing` (number): The amount of dietary fiber per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### nutrients Field
+The amount of nutrients in the product.
+
+A `NutritionFactsLabelV1Nutrient` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of nutrients to consume or not to exceed each day.
+* `name` (string): The name of nutrients of the product.
+* `per100G` (number): The amount of nutrients per 100g of the product.
+* `perServing` (number): The amount of nutrients per serving of the product.
+* `unit` (string): The unit of measurement for the amount of nutrients.
+Fields which are specific to this product; they are not used in any other product.
+
+### Protein Field
+The amount of protein in the product.
+
+A `NutritionFactsLabelV1Protein` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of protein to consume or not to exceed each day.
+* `per100G` (number): The amount of protein per 100g of the product.
+* `perServing` (number): The amount of protein per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Saturated Fat Field
+The amount of saturated fat in the product.
+
+A `NutritionFactsLabelV1SaturatedFat` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of saturated fat to consume or not to exceed each day.
+* `per100G` (number): The amount of saturated fat per 100g of the product.
+* `perServing` (number): The amount of saturated fat per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Serving Size Field
+The size of a single serving of the product.
+
+A `NutritionFactsLabelV1ServingSize` implements the following attributes:
+
+* `amount` (number): The amount of a single serving.
+* `unit` (string): The unit for the amount of a single serving.
+Fields which are specific to this product; they are not used in any other product.
+
+### sodium Field
+The amount of sodium in the product.
+
+A `NutritionFactsLabelV1Sodium` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of sodium to consume or not to exceed each day.
+* `per100G` (number): The amount of sodium per 100g of the product.
+* `perServing` (number): The amount of sodium per serving of the product.
+* `unit` (string): The unit of measurement for the amount of sodium.
+Fields which are specific to this product; they are not used in any other product.
+
+### Total Carbohydrate Field
+The total amount of carbohydrates in the product.
+
+A `NutritionFactsLabelV1TotalCarbohydrate` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of total carbohydrates to consume or not to exceed each day.
+* `per100G` (number): The amount of total carbohydrates per 100g of the product.
+* `perServing` (number): The amount of total carbohydrates per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Total Fat Field
+The total amount of fat in the product.
+
+A `NutritionFactsLabelV1TotalFat` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of total fat to consume or not to exceed each day.
+* `per100G` (number): The amount of total fat per 100g of the product.
+* `perServing` (number): The amount of total fat per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Total Sugars Field
+The total amount of sugars in the product.
+
+A `NutritionFactsLabelV1TotalSugar` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of total sugars to consume or not to exceed each day.
+* `per100G` (number): The amount of total sugars per 100g of the product.
+* `perServing` (number): The amount of total sugars per serving of the product.
+Fields which are specific to this product; they are not used in any other product.
+
+### Trans Fat Field
+The amount of trans fat in the product.
+
+A `NutritionFactsLabelV1TransFat` implements the following attributes:
+
+* `dailyValue` (number): DVs are the recommended amounts of trans fat to consume or not to exceed each day.
+* `per100G` (number): The amount of trans fat per 100g of the product.
+* `perServing` (number): The amount of trans fat per serving of the product.
+
+# Attributes
+The following fields are extracted for Nutrition Facts Label V1:
+
+## Added Sugars
+**addedSugars** ([NutritionFactsLabelV1AddedSugar](#added-sugars-field)): The amount of added sugars in the product.
+
+```js
+console.log(result.document.inference.prediction.addedSugars.value);
+```
+
+## Calories
+**calories** ([NutritionFactsLabelV1Calorie](#calories-field)): The amount of calories in the product.
+
+```js
+console.log(result.document.inference.prediction.calories.value);
+```
+
+## Cholesterol
+**cholesterol** ([NutritionFactsLabelV1Cholesterol](#cholesterol-field)): The amount of cholesterol in the product.
+
+```js
+console.log(result.document.inference.prediction.cholesterol.value);
+```
+
+## Dietary Fiber
+**dietaryFiber** ([NutritionFactsLabelV1DietaryFiber](#dietary-fiber-field)): The amount of dietary fiber in the product.
+
+```js
+console.log(result.document.inference.prediction.dietaryFiber.value);
+```
+
+## nutrients
+**nutrients** ([NutritionFactsLabelV1Nutrient](#nutrients-field)[]): The amount of nutrients in the product.
+
+```js
+for (const nutrientsElem of result.document.inference.prediction.nutrients) {
+  console.log(nutrientsElem.value);
+}
+```
+
+## Protein
+**protein** ([NutritionFactsLabelV1Protein](#protein-field)): The amount of protein in the product.
+
+```js
+console.log(result.document.inference.prediction.protein.value);
+```
+
+## Saturated Fat
+**saturatedFat** ([NutritionFactsLabelV1SaturatedFat](#saturated-fat-field)): The amount of saturated fat in the product.
+
+```js
+console.log(result.document.inference.prediction.saturatedFat.value);
+```
+
+## Serving per Box
+**servingPerBox** ([AmountField](#amount-field)): The number of servings in each box of the product.
+
+```js
+console.log(result.document.inference.prediction.servingPerBox.value);
+```
+
+## Serving Size
+**servingSize** ([NutritionFactsLabelV1ServingSize](#serving-size-field)): The size of a single serving of the product.
+
+```js
+console.log(result.document.inference.prediction.servingSize.value);
+```
+
+## sodium
+**sodium** ([NutritionFactsLabelV1Sodium](#sodium-field)): The amount of sodium in the product.
+
+```js
+console.log(result.document.inference.prediction.sodium.value);
+```
+
+## Total Carbohydrate
+**totalCarbohydrate** ([NutritionFactsLabelV1TotalCarbohydrate](#total-carbohydrate-field)): The total amount of carbohydrates in the product.
+
+```js
+console.log(result.document.inference.prediction.totalCarbohydrate.value);
+```
+
+## Total Fat
+**totalFat** ([NutritionFactsLabelV1TotalFat](#total-fat-field)): The total amount of fat in the product.
+
+```js
+console.log(result.document.inference.prediction.totalFat.value);
+```
+
+## Total Sugars
+**totalSugars** ([NutritionFactsLabelV1TotalSugar](#total-sugars-field)): The total amount of sugars in the product.
+
+```js
+console.log(result.document.inference.prediction.totalSugars.value);
+```
+
+## Trans Fat
+**transFat** ([NutritionFactsLabelV1TransFat](#trans-fat-field)): The amount of trans fat in the product.
+
+```js
+console.log(result.document.inference.prediction.transFat.value);
+```
+
+# Questions?
+[Join our Slack](https://join.slack.com/t/mindee-community/shared_invite/zt-2d0ds7dtz-DPAF81ZqTy20chsYpQBW5g)

--- a/docs/payslip_fra_v2.md
+++ b/docs/payslip_fra_v2.md
@@ -1,0 +1,221 @@
+---
+title: FR Payslip OCR Node.js
+category: 622b805aaec68102ea7fcbc2
+slug: nodejs-fr-payslip-ocr
+parentDoc: 609809574212d40077a040f1
+---
+The Node.js OCR SDK supports the [Payslip API](https://platform.mindee.com/mindee/payslip_fra).
+
+The [sample below](https://github.com/mindee/client-lib-test-data/blob/main/products/payslip_fra/default_sample.jpg) can be used for testing purposes.
+![Payslip sample](https://github.com/mindee/client-lib-test-data/blob/main/products/payslip_fra/default_sample.jpg?raw=true)
+
+# Quick-Start
+```js
+const mindee = require("mindee");
+// for TS or modules:
+// import * as mindee from "mindee";
+
+// Init a new client
+const mindeeClient = new mindee.Client({ apiKey: "my-api-key" });
+
+// Load a file from disk
+const inputSource = mindeeClient.docFromPath("/path/to/the/file.ext");
+
+// Parse the file
+const apiResponse = mindeeClient.enqueueAndParse(
+  mindee.product.fr.PayslipV2,
+  inputSource
+);
+
+// Handle the response Promise
+apiResponse.then((resp) => {
+  // print a string summary
+  console.log(resp.document.toString());
+});
+```
+# Field Types
+## Standard Fields
+These fields are generic and used in several products.
+
+### Basic Field
+Each prediction object contains a set of fields that inherit from the generic `Field` class.
+A typical `Field` object will have the following attributes:
+
+* **value** (`number | string`): corresponds to the field value. Can be `undefined` if no value was extracted.
+* **confidence** (`number`): the confidence score of the field prediction.
+* **boundingBox** (`[Point, Point, Point, Point]`): contains exactly 4 relative vertices (points) coordinates of a right rectangle containing the field in the document.
+* **polygon** (`Point[]`): contains the relative vertices coordinates (`Point`) of a polygon containing the field in the image.
+* **pageId** (`number`): the ID of the page, always `undefined` when at document-level.
+* **reconstructed** (`boolean`): indicates whether an object was reconstructed (not extracted as the API gave it).
+
+> **Note:** A `Point` simply refers to an array of two numbers (`[number, number]`).
+
+
+Aside from the previous attributes, all basic fields have access to a `toString()` method that can be used to print their value as a string.
+
+## Specific Fields
+Fields which are specific to this product; they are not used in any other product.
+
+### Bank Account Details Field
+Information about the employee's bank account.
+
+A `PayslipV2BankAccountDetail` implements the following attributes:
+
+* `bankName` (string): The name of the bank.
+* `iban` (string): The IBAN of the bank account.
+* `swift` (string): The SWIFT code of the bank.
+Fields which are specific to this product; they are not used in any other product.
+
+### Employee Field
+Information about the employee.
+
+A `PayslipV2Employee` implements the following attributes:
+
+* `address` (string): The address of the employee.
+* `dateOfBirth` (string): The date of birth of the employee.
+* `firstName` (string): The first name of the employee.
+* `lastName` (string): The last name of the employee.
+* `phoneNumber` (string): The phone number of the employee.
+* `registrationNumber` (string): The registration number of the employee.
+* `socialSecurityNumber` (string): The social security number of the employee.
+Fields which are specific to this product; they are not used in any other product.
+
+### Employer Field
+Information about the employer.
+
+A `PayslipV2Employer` implements the following attributes:
+
+* `address` (string): The address of the employer.
+* `companyId` (string): The company ID of the employer.
+* `companySite` (string): The site of the company.
+* `nafCode` (string): The NAF code of the employer.
+* `name` (string): The name of the employer.
+* `phoneNumber` (string): The phone number of the employer.
+* `urssafNumber` (string): The URSSAF number of the employer.
+Fields which are specific to this product; they are not used in any other product.
+
+### Employment Field
+Information about the employment.
+
+A `PayslipV2Employment` implements the following attributes:
+
+* `category` (string): The category of the employment.
+* `coefficient` (number): The coefficient of the employment.
+* `collectiveAgreement` (string): The collective agreement of the employment.
+* `jobTitle` (string): The job title of the employee.
+* `positionLevel` (string): The position level of the employment.
+* `startDate` (string): The start date of the employment.
+Fields which are specific to this product; they are not used in any other product.
+
+### Pay Detail Field
+Detailed information about the pay.
+
+A `PayslipV2PayDetail` implements the following attributes:
+
+* `grossSalary` (number): The gross salary of the employee.
+* `grossSalaryYtd` (number): The year-to-date gross salary of the employee.
+* `incomeTaxRate` (number): The income tax rate of the employee.
+* `incomeTaxWithheld` (number): The income tax withheld from the employee's pay.
+* `netPaid` (number): The net paid amount of the employee.
+* `netPaidBeforeTax` (number): The net paid amount before tax of the employee.
+* `netTaxable` (number): The net taxable amount of the employee.
+* `netTaxableYtd` (number): The year-to-date net taxable amount of the employee.
+* `totalCostEmployer` (number): The total cost to the employer.
+* `totalTaxesAndDeductions` (number): The total taxes and deductions of the employee.
+Fields which are specific to this product; they are not used in any other product.
+
+### Pay Period Field
+Information about the pay period.
+
+A `PayslipV2PayPeriod` implements the following attributes:
+
+* `endDate` (string): The end date of the pay period.
+* `month` (string): The month of the pay period.
+* `paymentDate` (string): The date of payment for the pay period.
+* `startDate` (string): The start date of the pay period.
+* `year` (string): The year of the pay period.
+Fields which are specific to this product; they are not used in any other product.
+
+### PTO Field
+Information about paid time off.
+
+A `PayslipV2Pto` implements the following attributes:
+
+* `accruedThisPeriod` (number): The amount of paid time off accrued in this period.
+* `balanceEndOfPeriod` (number): The balance of paid time off at the end of the period.
+* `usedThisPeriod` (number): The amount of paid time off used in this period.
+Fields which are specific to this product; they are not used in any other product.
+
+### Salary Details Field
+Detailed information about the earnings.
+
+A `PayslipV2SalaryDetail` implements the following attributes:
+
+* `amount` (number): The amount of the earnings.
+* `base` (number): The base value of the earnings.
+* `description` (string): The description of the earnings.
+* `rate` (number): The rate of the earnings.
+
+# Attributes
+The following fields are extracted for Payslip V2:
+
+## Bank Account Details
+**bankAccountDetails** ([PayslipV2BankAccountDetail](#bank-account-details-field)): Information about the employee's bank account.
+
+```js
+console.log(result.document.inference.prediction.bankAccountDetails.value);
+```
+
+## Employee
+**employee** ([PayslipV2Employee](#employee-field)): Information about the employee.
+
+```js
+console.log(result.document.inference.prediction.employee.value);
+```
+
+## Employer
+**employer** ([PayslipV2Employer](#employer-field)): Information about the employer.
+
+```js
+console.log(result.document.inference.prediction.employer.value);
+```
+
+## Employment
+**employment** ([PayslipV2Employment](#employment-field)): Information about the employment.
+
+```js
+console.log(result.document.inference.prediction.employment.value);
+```
+
+## Pay Detail
+**payDetail** ([PayslipV2PayDetail](#pay-detail-field)): Detailed information about the pay.
+
+```js
+console.log(result.document.inference.prediction.payDetail.value);
+```
+
+## Pay Period
+**payPeriod** ([PayslipV2PayPeriod](#pay-period-field)): Information about the pay period.
+
+```js
+console.log(result.document.inference.prediction.payPeriod.value);
+```
+
+## PTO
+**pto** ([PayslipV2Pto](#pto-field)): Information about paid time off.
+
+```js
+console.log(result.document.inference.prediction.pto.value);
+```
+
+## Salary Details
+**salaryDetails** ([PayslipV2SalaryDetail](#salary-details-field)[]): Detailed information about the earnings.
+
+```js
+for (const salaryDetailsElem of result.document.inference.prediction.salaryDetails) {
+  console.log(salaryDetailsElem.value);
+}
+```
+
+# Questions?
+[Join our Slack](https://join.slack.com/t/mindee-community/shared_invite/zt-2d0ds7dtz-DPAF81ZqTy20chsYpQBW5g)

--- a/docs/us_mail_v2.md
+++ b/docs/us_mail_v2.md
@@ -64,7 +64,7 @@ A typical `Field` object will have the following attributes:
 * **confidence** (`number`): the confidence score of the field prediction.
 * **boundingBox** (`[Point, Point, Point, Point]`): contains exactly 4 relative vertices (points) coordinates of a right rectangle containing the field in the document.
 * **polygon** (`Point[]`): contains the relative vertices coordinates (`Point`) of a polygon containing the field in the image.
-* **pageId** (`number`): the ID of the page, is `undefined` when at document-level.
+* **pageId** (`number`): the ID of the page, always `undefined` when at document-level.
 * **reconstructed** (`boolean`): indicates whether an object was reconstructed (not extracted as the API gave it).
 
 > **Note:** A `Point` simply refers to an array of two numbers (`[number, number]`).

--- a/src/parsing/common/index.ts
+++ b/src/parsing/common/index.ts
@@ -9,3 +9,4 @@ export { Prediction } from "./prediction";
 export { Page } from "./page";
 export { cleanOutString, lineSeparator } from "./summaryHelper";
 export * as extras from "./extras";
+export { floatToString, cleanSpecialChars } from "./summaryHelper";

--- a/src/parsing/common/summaryHelper.ts
+++ b/src/parsing/common/summaryHelper.ts
@@ -16,3 +16,12 @@ export function lineSeparator(columnSizes: number[], separator: string) {
   });
   return outStr;
 }
+
+/**
+ * Removes all line breaks and replaces them by the \n character in table displays.
+ * Also trims line breaks at the end of the string.
+ * @param outStr
+ */
+export function cleanSpaces(outStr: string) {
+  return outStr.replace(/\n/g, "\\n");
+}

--- a/src/parsing/common/summaryHelper.ts
+++ b/src/parsing/common/summaryHelper.ts
@@ -22,6 +22,17 @@ export function lineSeparator(columnSizes: number[], separator: string) {
  * Also trims line breaks at the end of the string.
  * @param outStr
  */
-export function cleanSpaces(outStr: string) {
-  return outStr.replace(/\n/g, "\\n");
+export function cleanSpecialChars(outStr: string) {
+  return outStr
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
+export function floatToString(value: number) {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 5,
+    useGrouping: false,
+  });
 }

--- a/src/parsing/common/summaryHelper.ts
+++ b/src/parsing/common/summaryHelper.ts
@@ -18,7 +18,7 @@ export function lineSeparator(columnSizes: number[], separator: string) {
 }
 
 /**
- * Removes all line breaks and replaces them by the \n character in table displays.
+ * Replaces all special characters like \n, \r, \t, with an equivalent that can be displayed on a single line.
  * Also trims line breaks at the end of the string.
  * @param outStr
  */
@@ -29,6 +29,9 @@ export function cleanSpecialChars(outStr: string) {
     .replace(/\t/g, "\\t");
 }
 
+/**
+ * Return a float as a string with at least 2 levels of precision.
+ */
 export function floatToString(value: number|null) {
   if (value === null){
     return "";

--- a/src/parsing/common/summaryHelper.ts
+++ b/src/parsing/common/summaryHelper.ts
@@ -29,7 +29,10 @@ export function cleanSpecialChars(outStr: string) {
     .replace(/\t/g, "\\t");
 }
 
-export function floatToString(value: number) {
+export function floatToString(value: number|null) {
+  if (value === null){
+    return "";
+  }
   return value.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 5,

--- a/src/parsing/standard/amount.ts
+++ b/src/parsing/standard/amount.ts
@@ -1,13 +1,6 @@
 import { Field } from "./field";
 import { BaseFieldConstructor } from "./base";
-
-export function floatToString(value: number) {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 3,
-    useGrouping: false,
-  });
-}
+import { floatToString } from "../common";
 
 /**
  * A field containing an amount value.

--- a/src/parsing/standard/amount.ts
+++ b/src/parsing/standard/amount.ts
@@ -19,7 +19,7 @@ export class AmountField extends Field {
     pageId = undefined,
   }: BaseFieldConstructor) {
     super({ prediction, valueKey, reconstructed, pageId });
-    this.value = +parseFloat(prediction[valueKey]).toFixed(3);
+    this.value = +parseFloat(prediction[valueKey]);
     if (isNaN(this.value)) {
       this.value = undefined;
       this.confidence = 0.0;

--- a/src/parsing/standard/index.ts
+++ b/src/parsing/standard/index.ts
@@ -3,7 +3,7 @@ export { Taxes, TaxField } from "./tax";
 export { PaymentDetailsField } from "./paymentDetails";
 export { BooleanField } from "./boolean";
 export { LocaleField } from "./locale";
-export { AmountField, floatToString } from "./amount";
+export { AmountField } from "./amount";
 export { DateField } from "./date";
 export { BaseField, BaseFieldConstructor } from "./base";
 export { Word } from "./word";

--- a/src/parsing/standard/tax.ts
+++ b/src/parsing/standard/tax.ts
@@ -1,7 +1,6 @@
-import { StringDict } from "../common";
+import { floatToString, StringDict } from "../common";
 import { Field } from "./field";
 import { BaseFieldConstructor } from "./base";
-import { floatToString } from "./amount";
 
 /**
  * @property {string} constructor.rateKey - Key to use to get the tax rate in the prediction dict.

--- a/src/product/billOfLading/billOfLadingV1.ts
+++ b/src/product/billOfLading/billOfLadingV1.ts
@@ -1,0 +1,34 @@
+import { Inference, StringDict, Page } from "../../parsing/common";
+import { BillOfLadingV1Document } from "./billOfLadingV1Document";
+
+/**
+ * Bill of Lading API version 1 inference prediction.
+ */
+export class BillOfLadingV1 extends Inference {
+  /** The endpoint's name. */
+  endpointName = "bill_of_lading";
+  /** The endpoint's version. */
+  endpointVersion = "1";
+  /** The document-level prediction. */
+  prediction: BillOfLadingV1Document;
+  /** The document's pages. */
+  pages: Page<BillOfLadingV1Document>[] = [];
+
+  constructor(rawPrediction: StringDict) {
+    super(rawPrediction);
+    this.prediction = new BillOfLadingV1Document(rawPrediction["prediction"]);
+    rawPrediction["pages"].forEach(
+      (page: StringDict) => {
+        if (page.prediction !== undefined && page.prediction !== null &&
+          Object.keys(page.prediction).length > 0) {
+          this.pages.push(new Page(
+            BillOfLadingV1Document,
+            page,
+            page["id"],
+            page["orientation"]
+          ));
+        }
+      }
+    );
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1Carrier.ts
+++ b/src/product/billOfLading/billOfLadingV1Carrier.ts
@@ -1,0 +1,71 @@
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The shipping company responsible for transporting the goods.
+ */
+export class BillOfLadingV1Carrier {
+  /** The name of the carrier. */
+  name: string | undefined;
+  /** The professional number of the carrier. */
+  professionalNumber: string | undefined;
+  /** The Standard Carrier Alpha Code (SCAC) of the carrier. */
+  scac: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.name = prediction["name"];
+    this.professionalNumber = prediction["professional_number"];
+    this.scac = prediction["scac"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      name: this.name ?? "",
+      professionalNumber: this.professionalNumber ?? "",
+      scac: this.scac ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Name: " +
+      printable.name +
+      ", Professional Number: " +
+      printable.professionalNumber +
+      ", SCAC: " +
+      printable.scac
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Name: ${printable.name}
+  :Professional Number: ${printable.professionalNumber}
+  :SCAC: ${printable.scac}`.trimEnd();
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1Carrier.ts
+++ b/src/product/billOfLading/billOfLadingV1Carrier.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,11 +7,11 @@ import { Polygon } from "../../geometry";
  */
 export class BillOfLadingV1Carrier {
   /** The name of the carrier. */
-  name: string | undefined;
+  name: string | null;
   /** The professional number of the carrier. */
-  professionalNumber: string | undefined;
+  professionalNumber: string | null;
   /** The Standard Carrier Alpha Code (SCAC) of the carrier. */
-  scac: string | undefined;
+  scac: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/billOfLading/billOfLadingV1Carrier.ts
+++ b/src/product/billOfLading/billOfLadingV1Carrier.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/billOfLading/billOfLadingV1CarrierItem.ts
+++ b/src/product/billOfLading/billOfLadingV1CarrierItem.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,17 +7,17 @@ import { Polygon } from "../../geometry";
  */
 export class BillOfLadingV1CarrierItem {
   /** A description of the item. */
-  description: string | undefined;
+  description: string | null;
   /** The gross weight of the item. */
-  grossWeight: number | undefined;
+  grossWeight: number | null;
   /** The measurement of the item. */
-  measurement: number | undefined;
+  measurement: number | null;
   /** The unit of measurement for the measurement. */
-  measurementUnit: string | undefined;
+  measurementUnit: string | null;
   /** The quantity of the item being shipped. */
-  quantity: number | undefined;
+  quantity: number | null;
   /** The unit of measurement for weights. */
-  weightUnit: string | undefined;
+  weightUnit: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -31,15 +30,33 @@ export class BillOfLadingV1CarrierItem {
 
   constructor({ prediction = {} }: StringDict) {
     this.description = prediction["description"];
-    if (prediction["gross_weight"] && !isNaN(prediction["gross_weight"])) {
-      this.grossWeight = +parseFloat(prediction["gross_weight"]).toFixed(3);
+    if (
+      prediction["gross_weight"] !== undefined &&
+      prediction["gross_weight"] !== null &&
+      !isNaN(prediction["gross_weight"])
+    ) {
+      this.grossWeight = +parseFloat(prediction["gross_weight"]);
+    } else {
+      this.grossWeight = null;
     }
-    if (prediction["measurement"] && !isNaN(prediction["measurement"])) {
-      this.measurement = +parseFloat(prediction["measurement"]).toFixed(3);
+    if (
+      prediction["measurement"] !== undefined &&
+      prediction["measurement"] !== null &&
+      !isNaN(prediction["measurement"])
+    ) {
+      this.measurement = +parseFloat(prediction["measurement"]);
+    } else {
+      this.measurement = null;
     }
     this.measurementUnit = prediction["measurement_unit"];
-    if (prediction["quantity"] && !isNaN(prediction["quantity"])) {
-      this.quantity = +parseFloat(prediction["quantity"]).toFixed(3);
+    if (
+      prediction["quantity"] !== undefined &&
+      prediction["quantity"] !== null &&
+      !isNaN(prediction["quantity"])
+    ) {
+      this.quantity = +parseFloat(prediction["quantity"]);
+    } else {
+      this.quantity = null;
     }
     this.weightUnit = prediction["weight_unit"];
     this.pageId = prediction["page_id"];
@@ -56,8 +73,8 @@ export class BillOfLadingV1CarrierItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       grossWeight:
         this.grossWeight !== undefined ? floatToString(this.grossWeight) : "",
@@ -65,14 +82,14 @@ export class BillOfLadingV1CarrierItem {
         this.measurement !== undefined ? floatToString(this.measurement) : "",
       measurementUnit: this.measurementUnit ?
         this.measurementUnit.length <= 16 ?
-          cleanSpaces(this.measurementUnit) :
-          cleanSpaces(this.measurementUnit).slice(0, 13) + "..." :
+          cleanSpecialChars(this.measurementUnit) :
+          cleanSpecialChars(this.measurementUnit).slice(0, 13) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       weightUnit: this.weightUnit ?
         this.weightUnit.length <= 11 ?
-          cleanSpaces(this.weightUnit) :
-          cleanSpaces(this.weightUnit).slice(0, 8) + "..." :
+          cleanSpecialChars(this.weightUnit) :
+          cleanSpecialChars(this.weightUnit).slice(0, 8) + "..." :
         "",
     };
   }

--- a/src/product/billOfLading/billOfLadingV1CarrierItem.ts
+++ b/src/product/billOfLading/billOfLadingV1CarrierItem.ts
@@ -114,6 +114,7 @@ export class BillOfLadingV1CarrierItem {
       printable.weightUnit
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/billOfLading/billOfLadingV1CarrierItem.ts
+++ b/src/product/billOfLading/billOfLadingV1CarrierItem.ts
@@ -1,0 +1,120 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The goods being shipped.
+ */
+export class BillOfLadingV1CarrierItem {
+  /** A description of the item. */
+  description: string | undefined;
+  /** The gross weight of the item. */
+  grossWeight: number | undefined;
+  /** The measurement of the item. */
+  measurement: number | undefined;
+  /** The unit of measurement for the measurement. */
+  measurementUnit: string | undefined;
+  /** The quantity of the item being shipped. */
+  quantity: number | undefined;
+  /** The unit of measurement for weights. */
+  weightUnit: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.description = prediction["description"];
+    if (prediction["gross_weight"] && !isNaN(prediction["gross_weight"])) {
+      this.grossWeight = +parseFloat(prediction["gross_weight"]).toFixed(3);
+    }
+    if (prediction["measurement"] && !isNaN(prediction["measurement"])) {
+      this.measurement = +parseFloat(prediction["measurement"]).toFixed(3);
+    }
+    this.measurementUnit = prediction["measurement_unit"];
+    if (prediction["quantity"] && !isNaN(prediction["quantity"])) {
+      this.quantity = +parseFloat(prediction["quantity"]).toFixed(3);
+    }
+    this.weightUnit = prediction["weight_unit"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      description: this.description ?
+        this.description.length <= 11 ?
+          this.description :
+          this.description.slice(0, 8) + "..." :
+        "",
+      grossWeight:
+        this.grossWeight !== undefined ? floatToString(this.grossWeight) : "",
+      measurement:
+        this.measurement !== undefined ? floatToString(this.measurement) : "",
+      measurementUnit: this.measurementUnit ?
+        this.measurementUnit.length <= 16 ?
+          this.measurementUnit :
+          this.measurementUnit.slice(0, 13) + "..." :
+        "",
+      quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
+      weightUnit: this.weightUnit ?
+        this.weightUnit.length <= 11 ?
+          this.weightUnit :
+          this.weightUnit.slice(0, 8) + "..." :
+        "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Description: " +
+      printable.description +
+      ", Gross Weight: " +
+      printable.grossWeight +
+      ", Measurement: " +
+      printable.measurement +
+      ", Measurement Unit: " +
+      printable.measurementUnit +
+      ", Quantity: " +
+      printable.quantity +
+      ", Weight Unit: " +
+      printable.weightUnit
+    );
+  }
+  /**
+   * Output in a format suitable for inclusion in an rST table.
+   */
+  toTableLine(): string {
+    const printable = this.#printableValues();
+    return (
+      "| " +
+      printable.description.padEnd(11) +
+      " | " +
+      printable.grossWeight.padEnd(12) +
+      " | " +
+      printable.measurement.padEnd(11) +
+      " | " +
+      printable.measurementUnit.padEnd(16) +
+      " | " +
+      printable.quantity.padEnd(8) +
+      " | " +
+      printable.weightUnit.padEnd(11) +
+      " |"
+    );
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1CarrierItem.ts
+++ b/src/product/billOfLading/billOfLadingV1CarrierItem.ts
@@ -54,9 +54,9 @@ export class BillOfLadingV1CarrierItem {
   #printableValues() {
     return {
       description: this.description ?
-        this.description.length <= 11 ?
+        this.description.length <= 36 ?
           this.description :
-          this.description.slice(0, 8) + "..." :
+          this.description.slice(0, 33) + "..." :
         "",
       grossWeight:
         this.grossWeight !== undefined ? floatToString(this.grossWeight) : "",
@@ -103,7 +103,7 @@ export class BillOfLadingV1CarrierItem {
     const printable = this.#printableValues();
     return (
       "| " +
-      printable.description.padEnd(11) +
+      printable.description.padEnd(36) +
       " | " +
       printable.grossWeight.padEnd(12) +
       " | " +

--- a/src/product/billOfLading/billOfLadingV1CarrierItem.ts
+++ b/src/product/billOfLading/billOfLadingV1CarrierItem.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -55,8 +56,8 @@ export class BillOfLadingV1CarrierItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       grossWeight:
         this.grossWeight !== undefined ? floatToString(this.grossWeight) : "",
@@ -64,14 +65,14 @@ export class BillOfLadingV1CarrierItem {
         this.measurement !== undefined ? floatToString(this.measurement) : "",
       measurementUnit: this.measurementUnit ?
         this.measurementUnit.length <= 16 ?
-          this.measurementUnit :
-          this.measurementUnit.slice(0, 13) + "..." :
+          cleanSpaces(this.measurementUnit) :
+          cleanSpaces(this.measurementUnit).slice(0, 13) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       weightUnit: this.weightUnit ?
         this.weightUnit.length <= 11 ?
-          this.weightUnit :
-          this.weightUnit.slice(0, 8) + "..." :
+          cleanSpaces(this.weightUnit) :
+          cleanSpaces(this.weightUnit).slice(0, 8) + "..." :
         "",
     };
   }

--- a/src/product/billOfLading/billOfLadingV1Consignee.ts
+++ b/src/product/billOfLading/billOfLadingV1Consignee.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/billOfLading/billOfLadingV1Consignee.ts
+++ b/src/product/billOfLading/billOfLadingV1Consignee.ts
@@ -1,0 +1,78 @@
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The party to whom the goods are being shipped.
+ */
+export class BillOfLadingV1Consignee {
+  /** The address of the consignee. */
+  address: string | undefined;
+  /** The  email of the shipper. */
+  email: string | undefined;
+  /** The name of the consignee. */
+  name: string | undefined;
+  /** The phone number of the consignee. */
+  phone: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.email = prediction["email"];
+    this.name = prediction["name"];
+    this.phone = prediction["phone"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      email: this.email ?? "",
+      name: this.name ?? "",
+      phone: this.phone ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Email: " +
+      printable.email +
+      ", Name: " +
+      printable.name +
+      ", Phone: " +
+      printable.phone
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Email: ${printable.email}
+  :Name: ${printable.name}
+  :Phone: ${printable.phone}`.trimEnd();
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1Consignee.ts
+++ b/src/product/billOfLading/billOfLadingV1Consignee.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,13 +7,13 @@ import { Polygon } from "../../geometry";
  */
 export class BillOfLadingV1Consignee {
   /** The address of the consignee. */
-  address: string | undefined;
+  address: string | null;
   /** The  email of the shipper. */
-  email: string | undefined;
+  email: string | null;
   /** The name of the consignee. */
-  name: string | undefined;
+  name: string | null;
   /** The phone number of the consignee. */
-  phone: string | undefined;
+  phone: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/billOfLading/billOfLadingV1Document.ts
+++ b/src/product/billOfLading/billOfLadingV1Document.ts
@@ -96,9 +96,9 @@ export class BillOfLadingV1Document implements Prediction {
   toString(): string {
     let carrierItemsSummary:string = "";
     if (this.carrierItems && this.carrierItems.length > 0) {
-      const carrierItemsColSizes:number[] = [13, 14, 13, 18, 10, 13];
+      const carrierItemsColSizes:number[] = [38, 14, 13, 18, 10, 13];
       carrierItemsSummary += "\n" + lineSeparator(carrierItemsColSizes, "-") + "\n  ";
-      carrierItemsSummary += "| Description ";
+      carrierItemsSummary += "| Description                          ";
       carrierItemsSummary += "| Gross Weight ";
       carrierItemsSummary += "| Measurement ";
       carrierItemsSummary += "| Measurement Unit ";

--- a/src/product/billOfLading/billOfLadingV1Document.ts
+++ b/src/product/billOfLading/billOfLadingV1Document.ts
@@ -11,7 +11,7 @@ import { BillOfLadingV1CarrierItem } from "./billOfLadingV1CarrierItem";
 import { DateField, StringField } from "../../parsing/standard";
 
 /**
- * Bill of Lading API version 1.0 document data.
+ * Bill of Lading API version 1.1 document data.
  */
 export class BillOfLadingV1Document implements Prediction {
   /** A unique identifier assigned to a Bill of Lading document. */

--- a/src/product/billOfLading/billOfLadingV1Document.ts
+++ b/src/product/billOfLading/billOfLadingV1Document.ts
@@ -1,0 +1,126 @@
+import {
+  Prediction,
+  StringDict,
+  cleanOutString,lineSeparator,
+} from "../../parsing/common";
+import { BillOfLadingV1Shipper } from "./billOfLadingV1Shipper";
+import { BillOfLadingV1Consignee } from "./billOfLadingV1Consignee";
+import { BillOfLadingV1NotifyParty } from "./billOfLadingV1NotifyParty";
+import { BillOfLadingV1Carrier } from "./billOfLadingV1Carrier";
+import { BillOfLadingV1CarrierItem } from "./billOfLadingV1CarrierItem";
+import { DateField, StringField } from "../../parsing/standard";
+
+/**
+ * Bill of Lading API version 1.0 document data.
+ */
+export class BillOfLadingV1Document implements Prediction {
+  /** A unique identifier assigned to a Bill of Lading document. */
+  billOfLadingNumber: StringField;
+  /** The shipping company responsible for transporting the goods. */
+  carrier: BillOfLadingV1Carrier;
+  /** The goods being shipped. */
+  carrierItems: BillOfLadingV1CarrierItem[] = [];
+  /** The party to whom the goods are being shipped. */
+  consignee: BillOfLadingV1Consignee;
+  /** The date when the bill of lading is issued. */
+  dateOfIssue: DateField;
+  /** The date when the vessel departs from the port of loading. */
+  departureDate: DateField;
+  /** The party to be notified of the arrival of the goods. */
+  notifyParty: BillOfLadingV1NotifyParty;
+  /** The place where the goods are to be delivered. */
+  placeOfDelivery: StringField;
+  /** The port where the goods are unloaded from the vessel. */
+  portOfDischarge: StringField;
+  /** The port where the goods are loaded onto the vessel. */
+  portOfLoading: StringField;
+  /** The party responsible for shipping the goods. */
+  shipper: BillOfLadingV1Shipper;
+
+  constructor(rawPrediction: StringDict, pageId?: number) {
+    this.billOfLadingNumber = new StringField({
+      prediction: rawPrediction["bill_of_lading_number"],
+      pageId: pageId,
+    });
+    this.carrier = new BillOfLadingV1Carrier({
+      prediction: rawPrediction["carrier"],
+      pageId: pageId,
+    });
+    rawPrediction["carrier_items"] &&
+      rawPrediction["carrier_items"].map(
+        (itemPrediction: StringDict) =>
+          this.carrierItems.push(
+            new BillOfLadingV1CarrierItem({
+              prediction: itemPrediction,
+              pageId: pageId,
+            })
+          )
+      );
+    this.consignee = new BillOfLadingV1Consignee({
+      prediction: rawPrediction["consignee"],
+      pageId: pageId,
+    });
+    this.dateOfIssue = new DateField({
+      prediction: rawPrediction["date_of_issue"],
+      pageId: pageId,
+    });
+    this.departureDate = new DateField({
+      prediction: rawPrediction["departure_date"],
+      pageId: pageId,
+    });
+    this.notifyParty = new BillOfLadingV1NotifyParty({
+      prediction: rawPrediction["notify_party"],
+      pageId: pageId,
+    });
+    this.placeOfDelivery = new StringField({
+      prediction: rawPrediction["place_of_delivery"],
+      pageId: pageId,
+    });
+    this.portOfDischarge = new StringField({
+      prediction: rawPrediction["port_of_discharge"],
+      pageId: pageId,
+    });
+    this.portOfLoading = new StringField({
+      prediction: rawPrediction["port_of_loading"],
+      pageId: pageId,
+    });
+    this.shipper = new BillOfLadingV1Shipper({
+      prediction: rawPrediction["shipper"],
+      pageId: pageId,
+    });
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    let carrierItemsSummary:string = "";
+    if (this.carrierItems && this.carrierItems.length > 0) {
+      const carrierItemsColSizes:number[] = [13, 14, 13, 18, 10, 13];
+      carrierItemsSummary += "\n" + lineSeparator(carrierItemsColSizes, "-") + "\n  ";
+      carrierItemsSummary += "| Description ";
+      carrierItemsSummary += "| Gross Weight ";
+      carrierItemsSummary += "| Measurement ";
+      carrierItemsSummary += "| Measurement Unit ";
+      carrierItemsSummary += "| Quantity ";
+      carrierItemsSummary += "| Weight Unit ";
+      carrierItemsSummary += "|\n" + lineSeparator(carrierItemsColSizes, "=");
+      carrierItemsSummary += this.carrierItems.map(
+        (item) =>
+          "\n  " + item.toTableLine() + "\n" + lineSeparator(carrierItemsColSizes, "-")
+      ).join("");
+    }
+    const outStr = `:Bill of Lading Number: ${this.billOfLadingNumber}
+:Shipper: ${this.shipper.toFieldList()}
+:Consignee: ${this.consignee.toFieldList()}
+:Notify Party: ${this.notifyParty.toFieldList()}
+:Carrier: ${this.carrier.toFieldList()}
+:Items: ${carrierItemsSummary}
+:Port of Loading: ${this.portOfLoading}
+:Port of Discharge: ${this.portOfDischarge}
+:Place of Delivery: ${this.placeOfDelivery}
+:Date of issue: ${this.dateOfIssue}
+:Departure Date: ${this.departureDate}`.trimEnd();
+    return cleanOutString(outStr);
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1NotifyParty.ts
+++ b/src/product/billOfLading/billOfLadingV1NotifyParty.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,13 +7,13 @@ import { Polygon } from "../../geometry";
  */
 export class BillOfLadingV1NotifyParty {
   /** The address of the notify party. */
-  address: string | undefined;
+  address: string | null;
   /** The  email of the shipper. */
-  email: string | undefined;
+  email: string | null;
   /** The name of the notify party. */
-  name: string | undefined;
+  name: string | null;
   /** The phone number of the notify party. */
-  phone: string | undefined;
+  phone: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/billOfLading/billOfLadingV1NotifyParty.ts
+++ b/src/product/billOfLading/billOfLadingV1NotifyParty.ts
@@ -1,0 +1,78 @@
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The party to be notified of the arrival of the goods.
+ */
+export class BillOfLadingV1NotifyParty {
+  /** The address of the notify party. */
+  address: string | undefined;
+  /** The  email of the shipper. */
+  email: string | undefined;
+  /** The name of the notify party. */
+  name: string | undefined;
+  /** The phone number of the notify party. */
+  phone: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.email = prediction["email"];
+    this.name = prediction["name"];
+    this.phone = prediction["phone"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      email: this.email ?? "",
+      name: this.name ?? "",
+      phone: this.phone ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Email: " +
+      printable.email +
+      ", Name: " +
+      printable.name +
+      ", Phone: " +
+      printable.phone
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Email: ${printable.email}
+  :Name: ${printable.name}
+  :Phone: ${printable.phone}`.trimEnd();
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1NotifyParty.ts
+++ b/src/product/billOfLading/billOfLadingV1NotifyParty.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/billOfLading/billOfLadingV1Shipper.ts
+++ b/src/product/billOfLading/billOfLadingV1Shipper.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,13 +7,13 @@ import { Polygon } from "../../geometry";
  */
 export class BillOfLadingV1Shipper {
   /** The address of the shipper. */
-  address: string | undefined;
+  address: string | null;
   /** The  email of the shipper. */
-  email: string | undefined;
+  email: string | null;
   /** The name of the shipper. */
-  name: string | undefined;
+  name: string | null;
   /** The phone number of the shipper. */
-  phone: string | undefined;
+  phone: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/billOfLading/billOfLadingV1Shipper.ts
+++ b/src/product/billOfLading/billOfLadingV1Shipper.ts
@@ -1,0 +1,78 @@
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The party responsible for shipping the goods.
+ */
+export class BillOfLadingV1Shipper {
+  /** The address of the shipper. */
+  address: string | undefined;
+  /** The  email of the shipper. */
+  email: string | undefined;
+  /** The name of the shipper. */
+  name: string | undefined;
+  /** The phone number of the shipper. */
+  phone: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.email = prediction["email"];
+    this.name = prediction["name"];
+    this.phone = prediction["phone"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      email: this.email ?? "",
+      name: this.name ?? "",
+      phone: this.phone ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Email: " +
+      printable.email +
+      ", Name: " +
+      printable.name +
+      ", Phone: " +
+      printable.phone
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Email: ${printable.email}
+  :Name: ${printable.name}
+  :Phone: ${printable.phone}`.trimEnd();
+  }
+}

--- a/src/product/billOfLading/billOfLadingV1Shipper.ts
+++ b/src/product/billOfLading/billOfLadingV1Shipper.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/billOfLading/index.ts
+++ b/src/product/billOfLading/index.ts
@@ -1,0 +1,1 @@
+export { BillOfLadingV1 } from "./billOfLadingV1";

--- a/src/product/billOfLading/internal.ts
+++ b/src/product/billOfLading/internal.ts
@@ -1,0 +1,7 @@
+export { BillOfLadingV1 } from "./billOfLadingV1";
+export { BillOfLadingV1Carrier } from "./billOfLadingV1Carrier";
+export { BillOfLadingV1CarrierItem } from "./billOfLadingV1CarrierItem";
+export { BillOfLadingV1Consignee } from "./billOfLadingV1Consignee";
+export { BillOfLadingV1Document } from "./billOfLadingV1Document";
+export { BillOfLadingV1NotifyParty } from "./billOfLadingV1NotifyParty";
+export { BillOfLadingV1Shipper } from "./billOfLadingV1Shipper";

--- a/src/product/financialDocument/financialDocumentV1LineItem.ts
+++ b/src/product/financialDocument/financialDocumentV1LineItem.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,21 +7,21 @@ import { Polygon } from "../../geometry";
  */
 export class FinancialDocumentV1LineItem {
   /** The item description. */
-  description: string | undefined;
+  description: string | null;
   /** The product code referring to the item. */
-  productCode: string | undefined;
+  productCode: string | null;
   /** The item quantity */
-  quantity: number | undefined;
+  quantity: number | null;
   /** The item tax amount. */
-  taxAmount: number | undefined;
+  taxAmount: number | null;
   /** The item tax rate in percentage. */
-  taxRate: number | undefined;
+  taxRate: number | null;
   /** The item total amount. */
-  totalAmount: number | undefined;
+  totalAmount: number | null;
   /** The item unit of measure. */
-  unitMeasure: string | undefined;
+  unitMeasure: string | null;
   /** The item unit price. */
-  unitPrice: number | undefined;
+  unitPrice: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -36,21 +35,51 @@ export class FinancialDocumentV1LineItem {
   constructor({ prediction = {} }: StringDict) {
     this.description = prediction["description"];
     this.productCode = prediction["product_code"];
-    if (prediction["quantity"] && !isNaN(prediction["quantity"])) {
-      this.quantity = +parseFloat(prediction["quantity"]).toFixed(3);
+    if (
+      prediction["quantity"] !== undefined &&
+      prediction["quantity"] !== null &&
+      !isNaN(prediction["quantity"])
+    ) {
+      this.quantity = +parseFloat(prediction["quantity"]);
+    } else {
+      this.quantity = null;
     }
-    if (prediction["tax_amount"] && !isNaN(prediction["tax_amount"])) {
-      this.taxAmount = +parseFloat(prediction["tax_amount"]).toFixed(3);
+    if (
+      prediction["tax_amount"] !== undefined &&
+      prediction["tax_amount"] !== null &&
+      !isNaN(prediction["tax_amount"])
+    ) {
+      this.taxAmount = +parseFloat(prediction["tax_amount"]);
+    } else {
+      this.taxAmount = null;
     }
-    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
-      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    if (
+      prediction["tax_rate"] !== undefined &&
+      prediction["tax_rate"] !== null &&
+      !isNaN(prediction["tax_rate"])
+    ) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]);
+    } else {
+      this.taxRate = null;
     }
-    if (prediction["total_amount"] && !isNaN(prediction["total_amount"])) {
-      this.totalAmount = +parseFloat(prediction["total_amount"]).toFixed(3);
+    if (
+      prediction["total_amount"] !== undefined &&
+      prediction["total_amount"] !== null &&
+      !isNaN(prediction["total_amount"])
+    ) {
+      this.totalAmount = +parseFloat(prediction["total_amount"]);
+    } else {
+      this.totalAmount = null;
     }
     this.unitMeasure = prediction["unit_measure"];
-    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
-      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    if (
+      prediction["unit_price"] !== undefined &&
+      prediction["unit_price"] !== null &&
+      !isNaN(prediction["unit_price"])
+    ) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]);
+    } else {
+      this.unitPrice = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -66,13 +95,13 @@ export class FinancialDocumentV1LineItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       productCode: this.productCode ?
         this.productCode.length <= 12 ?
-          cleanSpaces(this.productCode) :
-          cleanSpaces(this.productCode).slice(0, 9) + "..." :
+          cleanSpecialChars(this.productCode) :
+          cleanSpecialChars(this.productCode).slice(0, 9) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       taxAmount: this.taxAmount !== undefined ? floatToString(this.taxAmount) : "",
@@ -81,8 +110,8 @@ export class FinancialDocumentV1LineItem {
         this.totalAmount !== undefined ? floatToString(this.totalAmount) : "",
       unitMeasure: this.unitMeasure ?
         this.unitMeasure.length <= 15 ?
-          cleanSpaces(this.unitMeasure) :
-          cleanSpaces(this.unitMeasure).slice(0, 12) + "..." :
+          cleanSpecialChars(this.unitMeasure) :
+          cleanSpecialChars(this.unitMeasure).slice(0, 12) + "..." :
         "",
       unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
     };

--- a/src/product/financialDocument/financialDocumentV1LineItem.ts
+++ b/src/product/financialDocument/financialDocumentV1LineItem.ts
@@ -141,6 +141,7 @@ export class FinancialDocumentV1LineItem {
       printable.unitPrice
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/financialDocument/financialDocumentV1LineItem.ts
+++ b/src/product/financialDocument/financialDocumentV1LineItem.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -65,13 +66,13 @@ export class FinancialDocumentV1LineItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       productCode: this.productCode ?
         this.productCode.length <= 12 ?
-          this.productCode :
-          this.productCode.slice(0, 9) + "..." :
+          cleanSpaces(this.productCode) :
+          cleanSpaces(this.productCode).slice(0, 9) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       taxAmount: this.taxAmount !== undefined ? floatToString(this.taxAmount) : "",
@@ -80,8 +81,8 @@ export class FinancialDocumentV1LineItem {
         this.totalAmount !== undefined ? floatToString(this.totalAmount) : "",
       unitMeasure: this.unitMeasure ?
         this.unitMeasure.length <= 15 ?
-          this.unitMeasure :
-          this.unitMeasure.slice(0, 12) + "..." :
+          cleanSpaces(this.unitMeasure) :
+          cleanSpaces(this.unitMeasure).slice(0, 12) + "..." :
         "",
       unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
     };

--- a/src/product/fr/bankAccountDetails/bankAccountDetailsV2Bban.ts
+++ b/src/product/fr/bankAccountDetails/bankAccountDetailsV2Bban.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/bankAccountDetails/bankAccountDetailsV2Bban.ts
+++ b/src/product/fr/bankAccountDetails/bankAccountDetailsV2Bban.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,13 +7,13 @@ import { Polygon } from "../../../geometry";
  */
 export class BankAccountDetailsV2Bban {
   /** The BBAN bank code outputted as a string. */
-  bbanBankCode: string | undefined;
+  bbanBankCode: string | null;
   /** The BBAN branch code outputted as a string. */
-  bbanBranchCode: string | undefined;
+  bbanBranchCode: string | null;
   /** The BBAN key outputted as a string. */
-  bbanKey: string | undefined;
+  bbanKey: string | null;
   /** The BBAN Account number outputted as a string. */
-  bbanNumber: string | undefined;
+  bbanNumber: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/energyBill/energyBillV1.ts
+++ b/src/product/fr/energyBill/energyBillV1.ts
@@ -1,0 +1,34 @@
+import { Inference, StringDict, Page } from "../../../parsing/common";
+import { EnergyBillV1Document } from "./energyBillV1Document";
+
+/**
+ * Energy Bill API version 1 inference prediction.
+ */
+export class EnergyBillV1 extends Inference {
+  /** The endpoint's name. */
+  endpointName = "energy_bill_fra";
+  /** The endpoint's version. */
+  endpointVersion = "1";
+  /** The document-level prediction. */
+  prediction: EnergyBillV1Document;
+  /** The document's pages. */
+  pages: Page<EnergyBillV1Document>[] = [];
+
+  constructor(rawPrediction: StringDict) {
+    super(rawPrediction);
+    this.prediction = new EnergyBillV1Document(rawPrediction["prediction"]);
+    rawPrediction["pages"].forEach(
+      (page: StringDict) => {
+        if (page.prediction !== undefined && page.prediction !== null &&
+          Object.keys(page.prediction).length > 0) {
+          this.pages.push(new Page(
+            EnergyBillV1Document,
+            page,
+            page["id"],
+            page["orientation"]
+          ));
+        }
+      }
+    );
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1Document.ts
+++ b/src/product/fr/energyBill/energyBillV1Document.ts
@@ -1,0 +1,196 @@
+import {
+  Prediction,
+  StringDict,
+  cleanOutString,lineSeparator,
+} from "../../../parsing/common";
+import { EnergyBillV1EnergySupplier } from "./energyBillV1EnergySupplier";
+import { EnergyBillV1EnergyConsumer } from "./energyBillV1EnergyConsumer";
+import { EnergyBillV1Subscription } from "./energyBillV1Subscription";
+import { EnergyBillV1EnergyUsage } from "./energyBillV1EnergyUsage";
+import { EnergyBillV1TaxesAndContribution } from "./energyBillV1TaxesAndContribution";
+import { EnergyBillV1MeterDetail } from "./energyBillV1MeterDetail";
+import {
+  AmountField,
+  DateField,
+  StringField,
+} from "../../../parsing/standard";
+
+/**
+ * Energy Bill API version 1.0 document data.
+ */
+export class EnergyBillV1Document implements Prediction {
+  /** The unique identifier associated with a specific contract. */
+  contractId: StringField;
+  /** The unique identifier assigned to each electricity or gas consumption point. It specifies the exact location where the energy is delivered. */
+  deliveryPoint: StringField;
+  /** The date by which the payment for the energy invoice is due. */
+  dueDate: DateField;
+  /** The entity that consumes the energy. */
+  energyConsumer: EnergyBillV1EnergyConsumer;
+  /** The company that supplies the energy. */
+  energySupplier: EnergyBillV1EnergySupplier;
+  /** Details of energy consumption. */
+  energyUsage: EnergyBillV1EnergyUsage[] = [];
+  /** The date when the energy invoice was issued. */
+  invoiceDate: DateField;
+  /** The unique identifier of the energy invoice. */
+  invoiceNumber: StringField;
+  /** Information about the energy meter. */
+  meterDetails: EnergyBillV1MeterDetail;
+  /** The subscription details fee for the energy service. */
+  subscription: EnergyBillV1Subscription[] = [];
+  /** Details of Taxes and Contributions. */
+  taxesAndContributions: EnergyBillV1TaxesAndContribution[] = [];
+  /** The total amount to be paid for the energy invoice. */
+  totalAmount: AmountField;
+  /** The total amount to be paid for the energy invoice before taxes. */
+  totalBeforeTaxes: AmountField;
+  /** Total of taxes applied to the invoice. */
+  totalTaxes: AmountField;
+
+  constructor(rawPrediction: StringDict, pageId?: number) {
+    this.contractId = new StringField({
+      prediction: rawPrediction["contract_id"],
+      pageId: pageId,
+    });
+    this.deliveryPoint = new StringField({
+      prediction: rawPrediction["delivery_point"],
+      pageId: pageId,
+    });
+    this.dueDate = new DateField({
+      prediction: rawPrediction["due_date"],
+      pageId: pageId,
+    });
+    this.energyConsumer = new EnergyBillV1EnergyConsumer({
+      prediction: rawPrediction["energy_consumer"],
+      pageId: pageId,
+    });
+    this.energySupplier = new EnergyBillV1EnergySupplier({
+      prediction: rawPrediction["energy_supplier"],
+      pageId: pageId,
+    });
+    rawPrediction["energy_usage"] &&
+      rawPrediction["energy_usage"].map(
+        (itemPrediction: StringDict) =>
+          this.energyUsage.push(
+            new EnergyBillV1EnergyUsage({
+              prediction: itemPrediction,
+              pageId: pageId,
+            })
+          )
+      );
+    this.invoiceDate = new DateField({
+      prediction: rawPrediction["invoice_date"],
+      pageId: pageId,
+    });
+    this.invoiceNumber = new StringField({
+      prediction: rawPrediction["invoice_number"],
+      pageId: pageId,
+    });
+    this.meterDetails = new EnergyBillV1MeterDetail({
+      prediction: rawPrediction["meter_details"],
+      pageId: pageId,
+    });
+    rawPrediction["subscription"] &&
+      rawPrediction["subscription"].map(
+        (itemPrediction: StringDict) =>
+          this.subscription.push(
+            new EnergyBillV1Subscription({
+              prediction: itemPrediction,
+              pageId: pageId,
+            })
+          )
+      );
+    rawPrediction["taxes_and_contributions"] &&
+      rawPrediction["taxes_and_contributions"].map(
+        (itemPrediction: StringDict) =>
+          this.taxesAndContributions.push(
+            new EnergyBillV1TaxesAndContribution({
+              prediction: itemPrediction,
+              pageId: pageId,
+            })
+          )
+      );
+    this.totalAmount = new AmountField({
+      prediction: rawPrediction["total_amount"],
+      pageId: pageId,
+    });
+    this.totalBeforeTaxes = new AmountField({
+      prediction: rawPrediction["total_before_taxes"],
+      pageId: pageId,
+    });
+    this.totalTaxes = new AmountField({
+      prediction: rawPrediction["total_taxes"],
+      pageId: pageId,
+    });
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    let subscriptionSummary:string = "";
+    if (this.subscription && this.subscription.length > 0) {
+      const subscriptionColSizes:number[] = [13, 10, 12, 10, 7, 12];
+      subscriptionSummary += "\n" + lineSeparator(subscriptionColSizes, "-") + "\n  ";
+      subscriptionSummary += "| Description ";
+      subscriptionSummary += "| End Date ";
+      subscriptionSummary += "| Start Date ";
+      subscriptionSummary += "| Tax Rate ";
+      subscriptionSummary += "| Total ";
+      subscriptionSummary += "| Unit Price ";
+      subscriptionSummary += "|\n" + lineSeparator(subscriptionColSizes, "=");
+      subscriptionSummary += this.subscription.map(
+        (item) =>
+          "\n  " + item.toTableLine() + "\n" + lineSeparator(subscriptionColSizes, "-")
+      ).join("");
+    }
+    let energyUsageSummary:string = "";
+    if (this.energyUsage && this.energyUsage.length > 0) {
+      const energyUsageColSizes:number[] = [13, 10, 12, 10, 7, 12];
+      energyUsageSummary += "\n" + lineSeparator(energyUsageColSizes, "-") + "\n  ";
+      energyUsageSummary += "| Description ";
+      energyUsageSummary += "| End Date ";
+      energyUsageSummary += "| Start Date ";
+      energyUsageSummary += "| Tax Rate ";
+      energyUsageSummary += "| Total ";
+      energyUsageSummary += "| Unit Price ";
+      energyUsageSummary += "|\n" + lineSeparator(energyUsageColSizes, "=");
+      energyUsageSummary += this.energyUsage.map(
+        (item) =>
+          "\n  " + item.toTableLine() + "\n" + lineSeparator(energyUsageColSizes, "-")
+      ).join("");
+    }
+    let taxesAndContributionsSummary:string = "";
+    if (this.taxesAndContributions && this.taxesAndContributions.length > 0) {
+      const taxesAndContributionsColSizes:number[] = [13, 10, 12, 10, 7, 12];
+      taxesAndContributionsSummary += "\n" + lineSeparator(taxesAndContributionsColSizes, "-") + "\n  ";
+      taxesAndContributionsSummary += "| Description ";
+      taxesAndContributionsSummary += "| End Date ";
+      taxesAndContributionsSummary += "| Start Date ";
+      taxesAndContributionsSummary += "| Tax Rate ";
+      taxesAndContributionsSummary += "| Total ";
+      taxesAndContributionsSummary += "| Unit Price ";
+      taxesAndContributionsSummary += "|\n" + lineSeparator(taxesAndContributionsColSizes, "=");
+      taxesAndContributionsSummary += this.taxesAndContributions.map(
+        (item) =>
+          "\n  " + item.toTableLine() + "\n" + lineSeparator(taxesAndContributionsColSizes, "-")
+      ).join("");
+    }
+    const outStr = `:Invoice Number: ${this.invoiceNumber}
+:Contract ID: ${this.contractId}
+:Delivery Point: ${this.deliveryPoint}
+:Invoice Date: ${this.invoiceDate}
+:Due Date: ${this.dueDate}
+:Total Before Taxes: ${this.totalBeforeTaxes}
+:Total Taxes: ${this.totalTaxes}
+:Total Amount: ${this.totalAmount}
+:Energy Supplier: ${this.energySupplier.toFieldList()}
+:Energy Consumer: ${this.energyConsumer.toFieldList()}
+:Subscription: ${subscriptionSummary}
+:Energy Usage: ${energyUsageSummary}
+:Taxes and Contributions: ${taxesAndContributionsSummary}
+:Meter Details: ${this.meterDetails.toFieldList()}`.trimEnd();
+    return cleanOutString(outStr);
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1Document.ts
+++ b/src/product/fr/energyBill/energyBillV1Document.ts
@@ -134,13 +134,13 @@ export class EnergyBillV1Document implements Prediction {
   toString(): string {
     let subscriptionSummary:string = "";
     if (this.subscription && this.subscription.length > 0) {
-      const subscriptionColSizes:number[] = [38, 12, 12, 10, 8, 12];
+      const subscriptionColSizes:number[] = [38, 12, 12, 10, 11, 12];
       subscriptionSummary += "\n" + lineSeparator(subscriptionColSizes, "-") + "\n  ";
       subscriptionSummary += "| Description                          ";
       subscriptionSummary += "| End Date   ";
       subscriptionSummary += "| Start Date ";
       subscriptionSummary += "| Tax Rate ";
-      subscriptionSummary += "| Total  ";
+      subscriptionSummary += "| Total     ";
       subscriptionSummary += "| Unit Price ";
       subscriptionSummary += "|\n" + lineSeparator(subscriptionColSizes, "=");
       subscriptionSummary += this.subscription.map(
@@ -150,13 +150,13 @@ export class EnergyBillV1Document implements Prediction {
     }
     let energyUsageSummary:string = "";
     if (this.energyUsage && this.energyUsage.length > 0) {
-      const energyUsageColSizes:number[] = [38, 12, 12, 10, 8, 12];
+      const energyUsageColSizes:number[] = [38, 12, 12, 10, 11, 12];
       energyUsageSummary += "\n" + lineSeparator(energyUsageColSizes, "-") + "\n  ";
       energyUsageSummary += "| Description                          ";
       energyUsageSummary += "| End Date   ";
       energyUsageSummary += "| Start Date ";
       energyUsageSummary += "| Tax Rate ";
-      energyUsageSummary += "| Total  ";
+      energyUsageSummary += "| Total     ";
       energyUsageSummary += "| Unit Price ";
       energyUsageSummary += "|\n" + lineSeparator(energyUsageColSizes, "=");
       energyUsageSummary += this.energyUsage.map(
@@ -166,13 +166,13 @@ export class EnergyBillV1Document implements Prediction {
     }
     let taxesAndContributionsSummary:string = "";
     if (this.taxesAndContributions && this.taxesAndContributions.length > 0) {
-      const taxesAndContributionsColSizes:number[] = [38, 12, 12, 10, 8, 12];
+      const taxesAndContributionsColSizes:number[] = [38, 12, 12, 10, 11, 12];
       taxesAndContributionsSummary += "\n" + lineSeparator(taxesAndContributionsColSizes, "-") + "\n  ";
       taxesAndContributionsSummary += "| Description                          ";
       taxesAndContributionsSummary += "| End Date   ";
       taxesAndContributionsSummary += "| Start Date ";
       taxesAndContributionsSummary += "| Tax Rate ";
-      taxesAndContributionsSummary += "| Total  ";
+      taxesAndContributionsSummary += "| Total     ";
       taxesAndContributionsSummary += "| Unit Price ";
       taxesAndContributionsSummary += "|\n" + lineSeparator(taxesAndContributionsColSizes, "=");
       taxesAndContributionsSummary += this.taxesAndContributions.map(

--- a/src/product/fr/energyBill/energyBillV1Document.ts
+++ b/src/product/fr/energyBill/energyBillV1Document.ts
@@ -21,7 +21,10 @@ import {
 export class EnergyBillV1Document implements Prediction {
   /** The unique identifier associated with a specific contract. */
   contractId: StringField;
-  /** The unique identifier assigned to each electricity or gas consumption point. It specifies the exact location where the energy is delivered. */
+  /**
+   * The unique identifier assigned to each electricity or gas consumption point. It specifies the exact location where
+   * the energy is delivered.
+   */
   deliveryPoint: StringField;
   /** The date by which the payment for the energy invoice is due. */
   dueDate: DateField;
@@ -131,13 +134,13 @@ export class EnergyBillV1Document implements Prediction {
   toString(): string {
     let subscriptionSummary:string = "";
     if (this.subscription && this.subscription.length > 0) {
-      const subscriptionColSizes:number[] = [13, 10, 12, 10, 7, 12];
+      const subscriptionColSizes:number[] = [38, 12, 12, 10, 8, 12];
       subscriptionSummary += "\n" + lineSeparator(subscriptionColSizes, "-") + "\n  ";
-      subscriptionSummary += "| Description ";
-      subscriptionSummary += "| End Date ";
+      subscriptionSummary += "| Description                          ";
+      subscriptionSummary += "| End Date   ";
       subscriptionSummary += "| Start Date ";
       subscriptionSummary += "| Tax Rate ";
-      subscriptionSummary += "| Total ";
+      subscriptionSummary += "| Total  ";
       subscriptionSummary += "| Unit Price ";
       subscriptionSummary += "|\n" + lineSeparator(subscriptionColSizes, "=");
       subscriptionSummary += this.subscription.map(
@@ -147,13 +150,13 @@ export class EnergyBillV1Document implements Prediction {
     }
     let energyUsageSummary:string = "";
     if (this.energyUsage && this.energyUsage.length > 0) {
-      const energyUsageColSizes:number[] = [13, 10, 12, 10, 7, 12];
+      const energyUsageColSizes:number[] = [38, 12, 12, 10, 8, 12];
       energyUsageSummary += "\n" + lineSeparator(energyUsageColSizes, "-") + "\n  ";
-      energyUsageSummary += "| Description ";
-      energyUsageSummary += "| End Date ";
+      energyUsageSummary += "| Description                          ";
+      energyUsageSummary += "| End Date   ";
       energyUsageSummary += "| Start Date ";
       energyUsageSummary += "| Tax Rate ";
-      energyUsageSummary += "| Total ";
+      energyUsageSummary += "| Total  ";
       energyUsageSummary += "| Unit Price ";
       energyUsageSummary += "|\n" + lineSeparator(energyUsageColSizes, "=");
       energyUsageSummary += this.energyUsage.map(
@@ -163,13 +166,13 @@ export class EnergyBillV1Document implements Prediction {
     }
     let taxesAndContributionsSummary:string = "";
     if (this.taxesAndContributions && this.taxesAndContributions.length > 0) {
-      const taxesAndContributionsColSizes:number[] = [13, 10, 12, 10, 7, 12];
+      const taxesAndContributionsColSizes:number[] = [38, 12, 12, 10, 8, 12];
       taxesAndContributionsSummary += "\n" + lineSeparator(taxesAndContributionsColSizes, "-") + "\n  ";
-      taxesAndContributionsSummary += "| Description ";
-      taxesAndContributionsSummary += "| End Date ";
+      taxesAndContributionsSummary += "| Description                          ";
+      taxesAndContributionsSummary += "| End Date   ";
       taxesAndContributionsSummary += "| Start Date ";
       taxesAndContributionsSummary += "| Tax Rate ";
-      taxesAndContributionsSummary += "| Total ";
+      taxesAndContributionsSummary += "| Total  ";
       taxesAndContributionsSummary += "| Unit Price ";
       taxesAndContributionsSummary += "|\n" + lineSeparator(taxesAndContributionsColSizes, "=");
       taxesAndContributionsSummary += this.taxesAndContributions.map(

--- a/src/product/fr/energyBill/energyBillV1EnergyConsumer.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyConsumer.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/energyBill/energyBillV1EnergyConsumer.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyConsumer.ts
@@ -1,0 +1,64 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * The entity that consumes the energy.
+ */
+export class EnergyBillV1EnergyConsumer {
+  /** The address of the energy consumer. */
+  address: string | undefined;
+  /** The name of the energy consumer. */
+  name: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.name = prediction["name"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      name: this.name ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Name: " +
+      printable.name
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Name: ${printable.name}`.trimEnd();
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1EnergyConsumer.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyConsumer.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,9 +7,9 @@ import { Polygon } from "../../../geometry";
  */
 export class EnergyBillV1EnergyConsumer {
   /** The address of the energy consumer. */
-  address: string | undefined;
+  address: string | null;
   /** The name of the energy consumer. */
-  name: string | undefined;
+  name: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/energyBill/energyBillV1EnergySupplier.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergySupplier.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/energyBill/energyBillV1EnergySupplier.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergySupplier.ts
@@ -1,0 +1,64 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * The company that supplies the energy.
+ */
+export class EnergyBillV1EnergySupplier {
+  /** The address of the energy supplier. */
+  address: string | undefined;
+  /** The name of the energy supplier. */
+  name: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.name = prediction["name"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      name: this.name ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Name: " +
+      printable.name
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Name: ${printable.name}`.trimEnd();
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1EnergySupplier.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergySupplier.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,9 +7,9 @@ import { Polygon } from "../../../geometry";
  */
 export class EnergyBillV1EnergySupplier {
   /** The address of the energy supplier. */
-  address: string | undefined;
+  address: string | null;
   /** The name of the energy supplier. */
-  name: string | undefined;
+  name: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
@@ -112,6 +112,7 @@ export class EnergyBillV1EnergyUsage {
       printable.unitPrice
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -55,18 +56,18 @@ export class EnergyBillV1EnergyUsage {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
         this.endDate.length <= 10 ?
-          this.endDate :
-          this.endDate.slice(0, 7) + "..." :
+          cleanSpaces(this.endDate) :
+          cleanSpaces(this.endDate).slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
-          this.startDate :
-          this.startDate.slice(0, 7) + "..." :
+          cleanSpaces(this.startDate) :
+          cleanSpaces(this.startDate).slice(0, 7) + "..." :
         "",
       taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
       total: this.total !== undefined ? floatToString(this.total) : "",

--- a/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,17 +7,17 @@ import { Polygon } from "../../../geometry";
  */
 export class EnergyBillV1EnergyUsage {
   /** Description or details of the energy usage. */
-  description: string | undefined;
+  description: string | null;
   /** The end date of the energy usage. */
-  endDate: string | undefined;
+  endDate: string | null;
   /** The start date of the energy usage. */
-  startDate: string | undefined;
+  startDate: string | null;
   /** The rate of tax applied to the total cost. */
-  taxRate: number | undefined;
+  taxRate: number | null;
   /** The total cost of energy consumed. */
-  total: number | undefined;
+  total: number | null;
   /** The price per unit of energy consumed. */
-  unitPrice: number | undefined;
+  unitPrice: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -33,14 +32,32 @@ export class EnergyBillV1EnergyUsage {
     this.description = prediction["description"];
     this.endDate = prediction["end_date"];
     this.startDate = prediction["start_date"];
-    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
-      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    if (
+      prediction["tax_rate"] !== undefined &&
+      prediction["tax_rate"] !== null &&
+      !isNaN(prediction["tax_rate"])
+    ) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]);
+    } else {
+      this.taxRate = null;
     }
-    if (prediction["total"] && !isNaN(prediction["total"])) {
-      this.total = +parseFloat(prediction["total"]).toFixed(3);
+    if (
+      prediction["total"] !== undefined &&
+      prediction["total"] !== null &&
+      !isNaN(prediction["total"])
+    ) {
+      this.total = +parseFloat(prediction["total"]);
+    } else {
+      this.total = null;
     }
-    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
-      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    if (
+      prediction["unit_price"] !== undefined &&
+      prediction["unit_price"] !== null &&
+      !isNaN(prediction["unit_price"])
+    ) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]);
+    } else {
+      this.unitPrice = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -56,18 +73,18 @@ export class EnergyBillV1EnergyUsage {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
         this.endDate.length <= 10 ?
-          cleanSpaces(this.endDate) :
-          cleanSpaces(this.endDate).slice(0, 7) + "..." :
+          cleanSpecialChars(this.endDate) :
+          cleanSpecialChars(this.endDate).slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
-          cleanSpaces(this.startDate) :
-          cleanSpaces(this.startDate).slice(0, 7) + "..." :
+          cleanSpecialChars(this.startDate) :
+          cleanSpecialChars(this.startDate).slice(0, 7) + "..." :
         "",
       taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
       total: this.total !== undefined ? floatToString(this.total) : "",
@@ -110,7 +127,7 @@ export class EnergyBillV1EnergyUsage {
       " | " +
       printable.taxRate.padEnd(8) +
       " | " +
-      printable.total.padEnd(6) +
+      printable.total.padEnd(9) +
       " | " +
       printable.unitPrice.padEnd(10) +
       " |"

--- a/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
@@ -54,14 +54,14 @@ export class EnergyBillV1EnergyUsage {
   #printableValues() {
     return {
       description: this.description ?
-        this.description.length <= 11 ?
+        this.description.length <= 36 ?
           this.description :
-          this.description.slice(0, 8) + "..." :
+          this.description.slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
-        this.endDate.length <= 8 ?
+        this.endDate.length <= 10 ?
           this.endDate :
-          this.endDate.slice(0, 5) + "..." :
+          this.endDate.slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
@@ -101,15 +101,15 @@ export class EnergyBillV1EnergyUsage {
     const printable = this.#printableValues();
     return (
       "| " +
-      printable.description.padEnd(11) +
+      printable.description.padEnd(36) +
       " | " +
-      printable.endDate.padEnd(8) +
+      printable.endDate.padEnd(10) +
       " | " +
       printable.startDate.padEnd(10) +
       " | " +
       printable.taxRate.padEnd(8) +
       " | " +
-      printable.total.padEnd(5) +
+      printable.total.padEnd(6) +
       " | " +
       printable.unitPrice.padEnd(10) +
       " |"

--- a/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
+++ b/src/product/fr/energyBill/energyBillV1EnergyUsage.ts
@@ -1,0 +1,118 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Details of energy consumption.
+ */
+export class EnergyBillV1EnergyUsage {
+  /** Description or details of the energy usage. */
+  description: string | undefined;
+  /** The end date of the energy usage. */
+  endDate: string | undefined;
+  /** The start date of the energy usage. */
+  startDate: string | undefined;
+  /** The rate of tax applied to the total cost. */
+  taxRate: number | undefined;
+  /** The total cost of energy consumed. */
+  total: number | undefined;
+  /** The price per unit of energy consumed. */
+  unitPrice: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.description = prediction["description"];
+    this.endDate = prediction["end_date"];
+    this.startDate = prediction["start_date"];
+    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    }
+    if (prediction["total"] && !isNaN(prediction["total"])) {
+      this.total = +parseFloat(prediction["total"]).toFixed(3);
+    }
+    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      description: this.description ?
+        this.description.length <= 11 ?
+          this.description :
+          this.description.slice(0, 8) + "..." :
+        "",
+      endDate: this.endDate ?
+        this.endDate.length <= 8 ?
+          this.endDate :
+          this.endDate.slice(0, 5) + "..." :
+        "",
+      startDate: this.startDate ?
+        this.startDate.length <= 10 ?
+          this.startDate :
+          this.startDate.slice(0, 7) + "..." :
+        "",
+      taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
+      total: this.total !== undefined ? floatToString(this.total) : "",
+      unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Description: " +
+      printable.description +
+      ", End Date: " +
+      printable.endDate +
+      ", Start Date: " +
+      printable.startDate +
+      ", Tax Rate: " +
+      printable.taxRate +
+      ", Total: " +
+      printable.total +
+      ", Unit Price: " +
+      printable.unitPrice
+    );
+  }
+  /**
+   * Output in a format suitable for inclusion in an rST table.
+   */
+  toTableLine(): string {
+    const printable = this.#printableValues();
+    return (
+      "| " +
+      printable.description.padEnd(11) +
+      " | " +
+      printable.endDate.padEnd(8) +
+      " | " +
+      printable.startDate.padEnd(10) +
+      " | " +
+      printable.taxRate.padEnd(8) +
+      " | " +
+      printable.total.padEnd(5) +
+      " | " +
+      printable.unitPrice.padEnd(10) +
+      " |"
+    );
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1MeterDetail.ts
+++ b/src/product/fr/energyBill/energyBillV1MeterDetail.ts
@@ -1,0 +1,71 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about the energy meter.
+ */
+export class EnergyBillV1MeterDetail {
+  /** The unique identifier of the energy meter. */
+  meterNumber: string | undefined;
+  /** The type of energy meter. */
+  meterType: string | undefined;
+  /** The unit of measurement for energy consumption, which can be kW, m³, or L. */
+  unit: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.meterNumber = prediction["meter_number"];
+    this.meterType = prediction["meter_type"];
+    this.unit = prediction["unit"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      meterNumber: this.meterNumber ?? "",
+      meterType: this.meterType ?? "",
+      unit: this.unit ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Meter Number: " +
+      printable.meterNumber +
+      ", Meter Type: " +
+      printable.meterType +
+      ", Unit of Measure: " +
+      printable.unit
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Meter Number: ${printable.meterNumber}
+  :Meter Type: ${printable.meterType}
+  :Unit of Measure: ${printable.unit}`.trimEnd();
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1MeterDetail.ts
+++ b/src/product/fr/energyBill/energyBillV1MeterDetail.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/energyBill/energyBillV1MeterDetail.ts
+++ b/src/product/fr/energyBill/energyBillV1MeterDetail.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,11 +7,11 @@ import { Polygon } from "../../../geometry";
  */
 export class EnergyBillV1MeterDetail {
   /** The unique identifier of the energy meter. */
-  meterNumber: string | undefined;
+  meterNumber: string | null;
   /** The type of energy meter. */
-  meterType: string | undefined;
+  meterType: string | null;
   /** The unit of measurement for energy consumption, which can be kW, m³, or L. */
-  unit: string | undefined;
+  unit: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/energyBill/energyBillV1Subscription.ts
+++ b/src/product/fr/energyBill/energyBillV1Subscription.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,17 +7,17 @@ import { Polygon } from "../../../geometry";
  */
 export class EnergyBillV1Subscription {
   /** Description or details of the subscription. */
-  description: string | undefined;
+  description: string | null;
   /** The end date of the subscription. */
-  endDate: string | undefined;
+  endDate: string | null;
   /** The start date of the subscription. */
-  startDate: string | undefined;
+  startDate: string | null;
   /** The rate of tax applied to the total cost. */
-  taxRate: number | undefined;
+  taxRate: number | null;
   /** The total cost of subscription. */
-  total: number | undefined;
+  total: number | null;
   /** The price per unit of subscription. */
-  unitPrice: number | undefined;
+  unitPrice: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -33,14 +32,32 @@ export class EnergyBillV1Subscription {
     this.description = prediction["description"];
     this.endDate = prediction["end_date"];
     this.startDate = prediction["start_date"];
-    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
-      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    if (
+      prediction["tax_rate"] !== undefined &&
+      prediction["tax_rate"] !== null &&
+      !isNaN(prediction["tax_rate"])
+    ) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]);
+    } else {
+      this.taxRate = null;
     }
-    if (prediction["total"] && !isNaN(prediction["total"])) {
-      this.total = +parseFloat(prediction["total"]).toFixed(3);
+    if (
+      prediction["total"] !== undefined &&
+      prediction["total"] !== null &&
+      !isNaN(prediction["total"])
+    ) {
+      this.total = +parseFloat(prediction["total"]);
+    } else {
+      this.total = null;
     }
-    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
-      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    if (
+      prediction["unit_price"] !== undefined &&
+      prediction["unit_price"] !== null &&
+      !isNaN(prediction["unit_price"])
+    ) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]);
+    } else {
+      this.unitPrice = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -56,18 +73,18 @@ export class EnergyBillV1Subscription {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
         this.endDate.length <= 10 ?
-          cleanSpaces(this.endDate) :
-          cleanSpaces(this.endDate).slice(0, 7) + "..." :
+          cleanSpecialChars(this.endDate) :
+          cleanSpecialChars(this.endDate).slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
-          cleanSpaces(this.startDate) :
-          cleanSpaces(this.startDate).slice(0, 7) + "..." :
+          cleanSpecialChars(this.startDate) :
+          cleanSpecialChars(this.startDate).slice(0, 7) + "..." :
         "",
       taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
       total: this.total !== undefined ? floatToString(this.total) : "",
@@ -110,7 +127,7 @@ export class EnergyBillV1Subscription {
       " | " +
       printable.taxRate.padEnd(8) +
       " | " +
-      printable.total.padEnd(6) +
+      printable.total.padEnd(9) +
       " | " +
       printable.unitPrice.padEnd(10) +
       " |"

--- a/src/product/fr/energyBill/energyBillV1Subscription.ts
+++ b/src/product/fr/energyBill/energyBillV1Subscription.ts
@@ -112,6 +112,7 @@ export class EnergyBillV1Subscription {
       printable.unitPrice
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/fr/energyBill/energyBillV1Subscription.ts
+++ b/src/product/fr/energyBill/energyBillV1Subscription.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -55,18 +56,18 @@ export class EnergyBillV1Subscription {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
         this.endDate.length <= 10 ?
-          this.endDate :
-          this.endDate.slice(0, 7) + "..." :
+          cleanSpaces(this.endDate) :
+          cleanSpaces(this.endDate).slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
-          this.startDate :
-          this.startDate.slice(0, 7) + "..." :
+          cleanSpaces(this.startDate) :
+          cleanSpaces(this.startDate).slice(0, 7) + "..." :
         "",
       taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
       total: this.total !== undefined ? floatToString(this.total) : "",

--- a/src/product/fr/energyBill/energyBillV1Subscription.ts
+++ b/src/product/fr/energyBill/energyBillV1Subscription.ts
@@ -54,14 +54,14 @@ export class EnergyBillV1Subscription {
   #printableValues() {
     return {
       description: this.description ?
-        this.description.length <= 11 ?
+        this.description.length <= 36 ?
           this.description :
-          this.description.slice(0, 8) + "..." :
+          this.description.slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
-        this.endDate.length <= 8 ?
+        this.endDate.length <= 10 ?
           this.endDate :
-          this.endDate.slice(0, 5) + "..." :
+          this.endDate.slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
@@ -101,15 +101,15 @@ export class EnergyBillV1Subscription {
     const printable = this.#printableValues();
     return (
       "| " +
-      printable.description.padEnd(11) +
+      printable.description.padEnd(36) +
       " | " +
-      printable.endDate.padEnd(8) +
+      printable.endDate.padEnd(10) +
       " | " +
       printable.startDate.padEnd(10) +
       " | " +
       printable.taxRate.padEnd(8) +
       " | " +
-      printable.total.padEnd(5) +
+      printable.total.padEnd(6) +
       " | " +
       printable.unitPrice.padEnd(10) +
       " |"

--- a/src/product/fr/energyBill/energyBillV1Subscription.ts
+++ b/src/product/fr/energyBill/energyBillV1Subscription.ts
@@ -1,0 +1,118 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * The subscription details fee for the energy service.
+ */
+export class EnergyBillV1Subscription {
+  /** Description or details of the subscription. */
+  description: string | undefined;
+  /** The end date of the subscription. */
+  endDate: string | undefined;
+  /** The start date of the subscription. */
+  startDate: string | undefined;
+  /** The rate of tax applied to the total cost. */
+  taxRate: number | undefined;
+  /** The total cost of subscription. */
+  total: number | undefined;
+  /** The price per unit of subscription. */
+  unitPrice: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.description = prediction["description"];
+    this.endDate = prediction["end_date"];
+    this.startDate = prediction["start_date"];
+    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    }
+    if (prediction["total"] && !isNaN(prediction["total"])) {
+      this.total = +parseFloat(prediction["total"]).toFixed(3);
+    }
+    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      description: this.description ?
+        this.description.length <= 11 ?
+          this.description :
+          this.description.slice(0, 8) + "..." :
+        "",
+      endDate: this.endDate ?
+        this.endDate.length <= 8 ?
+          this.endDate :
+          this.endDate.slice(0, 5) + "..." :
+        "",
+      startDate: this.startDate ?
+        this.startDate.length <= 10 ?
+          this.startDate :
+          this.startDate.slice(0, 7) + "..." :
+        "",
+      taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
+      total: this.total !== undefined ? floatToString(this.total) : "",
+      unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Description: " +
+      printable.description +
+      ", End Date: " +
+      printable.endDate +
+      ", Start Date: " +
+      printable.startDate +
+      ", Tax Rate: " +
+      printable.taxRate +
+      ", Total: " +
+      printable.total +
+      ", Unit Price: " +
+      printable.unitPrice
+    );
+  }
+  /**
+   * Output in a format suitable for inclusion in an rST table.
+   */
+  toTableLine(): string {
+    const printable = this.#printableValues();
+    return (
+      "| " +
+      printable.description.padEnd(11) +
+      " | " +
+      printable.endDate.padEnd(8) +
+      " | " +
+      printable.startDate.padEnd(10) +
+      " | " +
+      printable.taxRate.padEnd(8) +
+      " | " +
+      printable.total.padEnd(5) +
+      " | " +
+      printable.unitPrice.padEnd(10) +
+      " |"
+    );
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
+++ b/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
@@ -54,14 +54,14 @@ export class EnergyBillV1TaxesAndContribution {
   #printableValues() {
     return {
       description: this.description ?
-        this.description.length <= 11 ?
+        this.description.length <= 36 ?
           this.description :
-          this.description.slice(0, 8) + "..." :
+          this.description.slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
-        this.endDate.length <= 8 ?
+        this.endDate.length <= 10 ?
           this.endDate :
-          this.endDate.slice(0, 5) + "..." :
+          this.endDate.slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
@@ -101,15 +101,15 @@ export class EnergyBillV1TaxesAndContribution {
     const printable = this.#printableValues();
     return (
       "| " +
-      printable.description.padEnd(11) +
+      printable.description.padEnd(36) +
       " | " +
-      printable.endDate.padEnd(8) +
+      printable.endDate.padEnd(10) +
       " | " +
       printable.startDate.padEnd(10) +
       " | " +
       printable.taxRate.padEnd(8) +
       " | " +
-      printable.total.padEnd(5) +
+      printable.total.padEnd(6) +
       " | " +
       printable.unitPrice.padEnd(10) +
       " |"

--- a/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
+++ b/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -55,18 +56,18 @@ export class EnergyBillV1TaxesAndContribution {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
         this.endDate.length <= 10 ?
-          this.endDate :
-          this.endDate.slice(0, 7) + "..." :
+          cleanSpaces(this.endDate) :
+          cleanSpaces(this.endDate).slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
-          this.startDate :
-          this.startDate.slice(0, 7) + "..." :
+          cleanSpaces(this.startDate) :
+          cleanSpaces(this.startDate).slice(0, 7) + "..." :
         "",
       taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
       total: this.total !== undefined ? floatToString(this.total) : "",

--- a/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
+++ b/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
@@ -1,0 +1,118 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Details of Taxes and Contributions.
+ */
+export class EnergyBillV1TaxesAndContribution {
+  /** Description or details of the Taxes and Contributions. */
+  description: string | undefined;
+  /** The end date of the Taxes and Contributions. */
+  endDate: string | undefined;
+  /** The start date of the Taxes and Contributions. */
+  startDate: string | undefined;
+  /** The rate of tax applied to the total cost. */
+  taxRate: number | undefined;
+  /** The total cost of Taxes and Contributions. */
+  total: number | undefined;
+  /** The price per unit of Taxes and Contributions. */
+  unitPrice: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.description = prediction["description"];
+    this.endDate = prediction["end_date"];
+    this.startDate = prediction["start_date"];
+    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    }
+    if (prediction["total"] && !isNaN(prediction["total"])) {
+      this.total = +parseFloat(prediction["total"]).toFixed(3);
+    }
+    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      description: this.description ?
+        this.description.length <= 11 ?
+          this.description :
+          this.description.slice(0, 8) + "..." :
+        "",
+      endDate: this.endDate ?
+        this.endDate.length <= 8 ?
+          this.endDate :
+          this.endDate.slice(0, 5) + "..." :
+        "",
+      startDate: this.startDate ?
+        this.startDate.length <= 10 ?
+          this.startDate :
+          this.startDate.slice(0, 7) + "..." :
+        "",
+      taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
+      total: this.total !== undefined ? floatToString(this.total) : "",
+      unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Description: " +
+      printable.description +
+      ", End Date: " +
+      printable.endDate +
+      ", Start Date: " +
+      printable.startDate +
+      ", Tax Rate: " +
+      printable.taxRate +
+      ", Total: " +
+      printable.total +
+      ", Unit Price: " +
+      printable.unitPrice
+    );
+  }
+  /**
+   * Output in a format suitable for inclusion in an rST table.
+   */
+  toTableLine(): string {
+    const printable = this.#printableValues();
+    return (
+      "| " +
+      printable.description.padEnd(11) +
+      " | " +
+      printable.endDate.padEnd(8) +
+      " | " +
+      printable.startDate.padEnd(10) +
+      " | " +
+      printable.taxRate.padEnd(8) +
+      " | " +
+      printable.total.padEnd(5) +
+      " | " +
+      printable.unitPrice.padEnd(10) +
+      " |"
+    );
+  }
+}

--- a/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
+++ b/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
@@ -112,6 +112,7 @@ export class EnergyBillV1TaxesAndContribution {
       printable.unitPrice
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
+++ b/src/product/fr/energyBill/energyBillV1TaxesAndContribution.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,17 +7,17 @@ import { Polygon } from "../../../geometry";
  */
 export class EnergyBillV1TaxesAndContribution {
   /** Description or details of the Taxes and Contributions. */
-  description: string | undefined;
+  description: string | null;
   /** The end date of the Taxes and Contributions. */
-  endDate: string | undefined;
+  endDate: string | null;
   /** The start date of the Taxes and Contributions. */
-  startDate: string | undefined;
+  startDate: string | null;
   /** The rate of tax applied to the total cost. */
-  taxRate: number | undefined;
+  taxRate: number | null;
   /** The total cost of Taxes and Contributions. */
-  total: number | undefined;
+  total: number | null;
   /** The price per unit of Taxes and Contributions. */
-  unitPrice: number | undefined;
+  unitPrice: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -33,14 +32,32 @@ export class EnergyBillV1TaxesAndContribution {
     this.description = prediction["description"];
     this.endDate = prediction["end_date"];
     this.startDate = prediction["start_date"];
-    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
-      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    if (
+      prediction["tax_rate"] !== undefined &&
+      prediction["tax_rate"] !== null &&
+      !isNaN(prediction["tax_rate"])
+    ) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]);
+    } else {
+      this.taxRate = null;
     }
-    if (prediction["total"] && !isNaN(prediction["total"])) {
-      this.total = +parseFloat(prediction["total"]).toFixed(3);
+    if (
+      prediction["total"] !== undefined &&
+      prediction["total"] !== null &&
+      !isNaN(prediction["total"])
+    ) {
+      this.total = +parseFloat(prediction["total"]);
+    } else {
+      this.total = null;
     }
-    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
-      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    if (
+      prediction["unit_price"] !== undefined &&
+      prediction["unit_price"] !== null &&
+      !isNaN(prediction["unit_price"])
+    ) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]);
+    } else {
+      this.unitPrice = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -56,18 +73,18 @@ export class EnergyBillV1TaxesAndContribution {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       endDate: this.endDate ?
         this.endDate.length <= 10 ?
-          cleanSpaces(this.endDate) :
-          cleanSpaces(this.endDate).slice(0, 7) + "..." :
+          cleanSpecialChars(this.endDate) :
+          cleanSpecialChars(this.endDate).slice(0, 7) + "..." :
         "",
       startDate: this.startDate ?
         this.startDate.length <= 10 ?
-          cleanSpaces(this.startDate) :
-          cleanSpaces(this.startDate).slice(0, 7) + "..." :
+          cleanSpecialChars(this.startDate) :
+          cleanSpecialChars(this.startDate).slice(0, 7) + "..." :
         "",
       taxRate: this.taxRate !== undefined ? floatToString(this.taxRate) : "",
       total: this.total !== undefined ? floatToString(this.total) : "",
@@ -110,7 +127,7 @@ export class EnergyBillV1TaxesAndContribution {
       " | " +
       printable.taxRate.padEnd(8) +
       " | " +
-      printable.total.padEnd(6) +
+      printable.total.padEnd(9) +
       " | " +
       printable.unitPrice.padEnd(10) +
       " |"

--- a/src/product/fr/energyBill/index.ts
+++ b/src/product/fr/energyBill/index.ts
@@ -1,0 +1,1 @@
+export { EnergyBillV1 } from "./energyBillV1";

--- a/src/product/fr/energyBill/internal.ts
+++ b/src/product/fr/energyBill/internal.ts
@@ -1,0 +1,8 @@
+export { EnergyBillV1 } from "./energyBillV1";
+export { EnergyBillV1Document } from "./energyBillV1Document";
+export { EnergyBillV1EnergyConsumer } from "./energyBillV1EnergyConsumer";
+export { EnergyBillV1EnergySupplier } from "./energyBillV1EnergySupplier";
+export { EnergyBillV1EnergyUsage } from "./energyBillV1EnergyUsage";
+export { EnergyBillV1MeterDetail } from "./energyBillV1MeterDetail";
+export { EnergyBillV1Subscription } from "./energyBillV1Subscription";
+export { EnergyBillV1TaxesAndContribution } from "./energyBillV1TaxesAndContribution";

--- a/src/product/fr/index.ts
+++ b/src/product/fr/index.ts
@@ -2,5 +2,7 @@ export { BankAccountDetailsV1 } from "./bankAccountDetails/bankAccountDetailsV1"
 export { BankAccountDetailsV2 } from "./bankAccountDetails/bankAccountDetailsV2";
 export { CarteGriseV1 } from "./carteGrise/carteGriseV1";
 export { CarteVitaleV1 } from "./carteVitale/carteVitaleV1";
+export { EnergyBillV1 } from "./energyBill/energyBillV1";
 export { IdCardV1 } from "./idCard/idCardV1";
 export { IdCardV2 } from "./idCard/idCardV2";
+export { PayslipV2 } from "./payslip/payslipV2";

--- a/src/product/fr/internal.ts
+++ b/src/product/fr/internal.ts
@@ -1,4 +1,6 @@
 export * as bankAccountDetails from "./bankAccountDetails/internal";
 export * as carteGrise from "./carteGrise/internal";
 export * as carteVitale from "./carteVitale/internal";
+export * as energyBill from "./energyBill/internal";
 export * as idCard from "./idCard/internal";
+export * as payslip from "./payslip/internal";

--- a/src/product/fr/payslip/index.ts
+++ b/src/product/fr/payslip/index.ts
@@ -1,0 +1,1 @@
+export { PayslipV2 } from "./payslipV2";

--- a/src/product/fr/payslip/internal.ts
+++ b/src/product/fr/payslip/internal.ts
@@ -1,0 +1,10 @@
+export { PayslipV2 } from "./payslipV2";
+export { PayslipV2BankAccountDetail } from "./payslipV2BankAccountDetail";
+export { PayslipV2Document } from "./payslipV2Document";
+export { PayslipV2Employee } from "./payslipV2Employee";
+export { PayslipV2Employer } from "./payslipV2Employer";
+export { PayslipV2Employment } from "./payslipV2Employment";
+export { PayslipV2PayDetail } from "./payslipV2PayDetail";
+export { PayslipV2PayPeriod } from "./payslipV2PayPeriod";
+export { PayslipV2Pto } from "./payslipV2Pto";
+export { PayslipV2SalaryDetail } from "./payslipV2SalaryDetail";

--- a/src/product/fr/payslip/payslipV2.ts
+++ b/src/product/fr/payslip/payslipV2.ts
@@ -1,0 +1,34 @@
+import { Inference, StringDict, Page } from "../../../parsing/common";
+import { PayslipV2Document } from "./payslipV2Document";
+
+/**
+ * Payslip API version 2 inference prediction.
+ */
+export class PayslipV2 extends Inference {
+  /** The endpoint's name. */
+  endpointName = "payslip_fra";
+  /** The endpoint's version. */
+  endpointVersion = "2";
+  /** The document-level prediction. */
+  prediction: PayslipV2Document;
+  /** The document's pages. */
+  pages: Page<PayslipV2Document>[] = [];
+
+  constructor(rawPrediction: StringDict) {
+    super(rawPrediction);
+    this.prediction = new PayslipV2Document(rawPrediction["prediction"]);
+    rawPrediction["pages"].forEach(
+      (page: StringDict) => {
+        if (page.prediction !== undefined && page.prediction !== null &&
+          Object.keys(page.prediction).length > 0) {
+          this.pages.push(new Page(
+            PayslipV2Document,
+            page,
+            page["id"],
+            page["orientation"]
+          ));
+        }
+      }
+    );
+  }
+}

--- a/src/product/fr/payslip/payslipV2BankAccountDetail.ts
+++ b/src/product/fr/payslip/payslipV2BankAccountDetail.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2BankAccountDetail.ts
+++ b/src/product/fr/payslip/payslipV2BankAccountDetail.ts
@@ -1,0 +1,71 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about the employee's bank account.
+ */
+export class PayslipV2BankAccountDetail {
+  /** The name of the bank. */
+  bankName: string | undefined;
+  /** The IBAN of the bank account. */
+  iban: string | undefined;
+  /** The SWIFT code of the bank. */
+  swift: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.bankName = prediction["bank_name"];
+    this.iban = prediction["iban"];
+    this.swift = prediction["swift"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      bankName: this.bankName ?? "",
+      iban: this.iban ?? "",
+      swift: this.swift ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Bank Name: " +
+      printable.bankName +
+      ", IBAN: " +
+      printable.iban +
+      ", SWIFT: " +
+      printable.swift
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Bank Name: ${printable.bankName}
+  :IBAN: ${printable.iban}
+  :SWIFT: ${printable.swift}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2BankAccountDetail.ts
+++ b/src/product/fr/payslip/payslipV2BankAccountDetail.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,11 +7,11 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2BankAccountDetail {
   /** The name of the bank. */
-  bankName: string | undefined;
+  bankName: string | null;
   /** The IBAN of the bank account. */
-  iban: string | undefined;
+  iban: string | null;
   /** The SWIFT code of the bank. */
-  swift: string | undefined;
+  swift: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/payslip/payslipV2Document.ts
+++ b/src/product/fr/payslip/payslipV2Document.ts
@@ -1,0 +1,106 @@
+import {
+  Prediction,
+  StringDict,
+  cleanOutString,lineSeparator,
+} from "../../../parsing/common";
+import { PayslipV2Employee } from "./payslipV2Employee";
+import { PayslipV2Employer } from "./payslipV2Employer";
+import { PayslipV2BankAccountDetail } from "./payslipV2BankAccountDetail";
+import { PayslipV2Employment } from "./payslipV2Employment";
+import { PayslipV2SalaryDetail } from "./payslipV2SalaryDetail";
+import { PayslipV2PayDetail } from "./payslipV2PayDetail";
+import { PayslipV2Pto } from "./payslipV2Pto";
+import { PayslipV2PayPeriod } from "./payslipV2PayPeriod";
+
+
+/**
+ * Payslip API version 2.0 document data.
+ */
+export class PayslipV2Document implements Prediction {
+  /** Information about the employee's bank account. */
+  bankAccountDetails: PayslipV2BankAccountDetail;
+  /** Information about the employee. */
+  employee: PayslipV2Employee;
+  /** Information about the employer. */
+  employer: PayslipV2Employer;
+  /** Information about the employment. */
+  employment: PayslipV2Employment;
+  /** Detailed information about the pay. */
+  payDetail: PayslipV2PayDetail;
+  /** Information about the pay period. */
+  payPeriod: PayslipV2PayPeriod;
+  /** Information about paid time off. */
+  pto: PayslipV2Pto;
+  /** Detailed information about the earnings. */
+  salaryDetails: PayslipV2SalaryDetail[] = [];
+
+  constructor(rawPrediction: StringDict, pageId?: number) {
+    this.bankAccountDetails = new PayslipV2BankAccountDetail({
+      prediction: rawPrediction["bank_account_details"],
+      pageId: pageId,
+    });
+    this.employee = new PayslipV2Employee({
+      prediction: rawPrediction["employee"],
+      pageId: pageId,
+    });
+    this.employer = new PayslipV2Employer({
+      prediction: rawPrediction["employer"],
+      pageId: pageId,
+    });
+    this.employment = new PayslipV2Employment({
+      prediction: rawPrediction["employment"],
+      pageId: pageId,
+    });
+    this.payDetail = new PayslipV2PayDetail({
+      prediction: rawPrediction["pay_detail"],
+      pageId: pageId,
+    });
+    this.payPeriod = new PayslipV2PayPeriod({
+      prediction: rawPrediction["pay_period"],
+      pageId: pageId,
+    });
+    this.pto = new PayslipV2Pto({
+      prediction: rawPrediction["pto"],
+      pageId: pageId,
+    });
+    rawPrediction["salary_details"] &&
+      rawPrediction["salary_details"].map(
+        (itemPrediction: StringDict) =>
+          this.salaryDetails.push(
+            new PayslipV2SalaryDetail({
+              prediction: itemPrediction,
+              pageId: pageId,
+            })
+          )
+      );
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    let salaryDetailsSummary:string = "";
+    if (this.salaryDetails && this.salaryDetails.length > 0) {
+      const salaryDetailsColSizes:number[] = [8, 6, 13, 6];
+      salaryDetailsSummary += "\n" + lineSeparator(salaryDetailsColSizes, "-") + "\n  ";
+      salaryDetailsSummary += "| Amount ";
+      salaryDetailsSummary += "| Base ";
+      salaryDetailsSummary += "| Description ";
+      salaryDetailsSummary += "| Rate ";
+      salaryDetailsSummary += "|\n" + lineSeparator(salaryDetailsColSizes, "=");
+      salaryDetailsSummary += this.salaryDetails.map(
+        (item) =>
+          "\n  " + item.toTableLine() + "\n" + lineSeparator(salaryDetailsColSizes, "-")
+      ).join("");
+    }
+    const outStr = `:Employee: ${this.employee.toFieldList()}
+:Employer: ${this.employer.toFieldList()}
+:Bank Account Details: ${this.bankAccountDetails.toFieldList()}
+:Employment: ${this.employment.toFieldList()}
+:Salary Details: ${salaryDetailsSummary}
+:Pay Detail: ${this.payDetail.toFieldList()}
+:PTO: ${this.pto.toFieldList()}
+:Pay Period: ${this.payPeriod.toFieldList()}`.trimEnd();
+    return cleanOutString(outStr);
+  }
+}

--- a/src/product/fr/payslip/payslipV2Document.ts
+++ b/src/product/fr/payslip/payslipV2Document.ts
@@ -81,12 +81,12 @@ export class PayslipV2Document implements Prediction {
   toString(): string {
     let salaryDetailsSummary:string = "";
     if (this.salaryDetails && this.salaryDetails.length > 0) {
-      const salaryDetailsColSizes:number[] = [8, 6, 13, 6];
+      const salaryDetailsColSizes:number[] = [14, 10, 38, 10];
       salaryDetailsSummary += "\n" + lineSeparator(salaryDetailsColSizes, "-") + "\n  ";
-      salaryDetailsSummary += "| Amount ";
-      salaryDetailsSummary += "| Base ";
-      salaryDetailsSummary += "| Description ";
-      salaryDetailsSummary += "| Rate ";
+      salaryDetailsSummary += "| Amount       ";
+      salaryDetailsSummary += "| Base     ";
+      salaryDetailsSummary += "| Description                          ";
+      salaryDetailsSummary += "| Rate     ";
       salaryDetailsSummary += "|\n" + lineSeparator(salaryDetailsColSizes, "=");
       salaryDetailsSummary += this.salaryDetails.map(
         (item) =>

--- a/src/product/fr/payslip/payslipV2Document.ts
+++ b/src/product/fr/payslip/payslipV2Document.ts
@@ -81,12 +81,12 @@ export class PayslipV2Document implements Prediction {
   toString(): string {
     let salaryDetailsSummary:string = "";
     if (this.salaryDetails && this.salaryDetails.length > 0) {
-      const salaryDetailsColSizes:number[] = [14, 10, 38, 10];
+      const salaryDetailsColSizes:number[] = [14, 11, 38, 11];
       salaryDetailsSummary += "\n" + lineSeparator(salaryDetailsColSizes, "-") + "\n  ";
       salaryDetailsSummary += "| Amount       ";
-      salaryDetailsSummary += "| Base     ";
+      salaryDetailsSummary += "| Base      ";
       salaryDetailsSummary += "| Description                          ";
-      salaryDetailsSummary += "| Rate     ";
+      salaryDetailsSummary += "| Rate      ";
       salaryDetailsSummary += "|\n" + lineSeparator(salaryDetailsColSizes, "=");
       salaryDetailsSummary += this.salaryDetails.map(
         (item) =>

--- a/src/product/fr/payslip/payslipV2Employee.ts
+++ b/src/product/fr/payslip/payslipV2Employee.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2Employee.ts
+++ b/src/product/fr/payslip/payslipV2Employee.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,19 +7,19 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2Employee {
   /** The address of the employee. */
-  address: string | undefined;
+  address: string | null;
   /** The date of birth of the employee. */
-  dateOfBirth: string | undefined;
+  dateOfBirth: string | null;
   /** The first name of the employee. */
-  firstName: string | undefined;
+  firstName: string | null;
   /** The last name of the employee. */
-  lastName: string | undefined;
+  lastName: string | null;
   /** The phone number of the employee. */
-  phoneNumber: string | undefined;
+  phoneNumber: string | null;
   /** The registration number of the employee. */
-  registrationNumber: string | undefined;
+  registrationNumber: string | null;
   /** The social security number of the employee. */
-  socialSecurityNumber: string | undefined;
+  socialSecurityNumber: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/payslip/payslipV2Employee.ts
+++ b/src/product/fr/payslip/payslipV2Employee.ts
@@ -1,0 +1,99 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about the employee.
+ */
+export class PayslipV2Employee {
+  /** The address of the employee. */
+  address: string | undefined;
+  /** The date of birth of the employee. */
+  dateOfBirth: string | undefined;
+  /** The first name of the employee. */
+  firstName: string | undefined;
+  /** The last name of the employee. */
+  lastName: string | undefined;
+  /** The phone number of the employee. */
+  phoneNumber: string | undefined;
+  /** The registration number of the employee. */
+  registrationNumber: string | undefined;
+  /** The social security number of the employee. */
+  socialSecurityNumber: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.dateOfBirth = prediction["date_of_birth"];
+    this.firstName = prediction["first_name"];
+    this.lastName = prediction["last_name"];
+    this.phoneNumber = prediction["phone_number"];
+    this.registrationNumber = prediction["registration_number"];
+    this.socialSecurityNumber = prediction["social_security_number"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      dateOfBirth: this.dateOfBirth ?? "",
+      firstName: this.firstName ?? "",
+      lastName: this.lastName ?? "",
+      phoneNumber: this.phoneNumber ?? "",
+      registrationNumber: this.registrationNumber ?? "",
+      socialSecurityNumber: this.socialSecurityNumber ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Date of Birth: " +
+      printable.dateOfBirth +
+      ", First Name: " +
+      printable.firstName +
+      ", Last Name: " +
+      printable.lastName +
+      ", Phone Number: " +
+      printable.phoneNumber +
+      ", Registration Number: " +
+      printable.registrationNumber +
+      ", Social Security Number: " +
+      printable.socialSecurityNumber
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Date of Birth: ${printable.dateOfBirth}
+  :First Name: ${printable.firstName}
+  :Last Name: ${printable.lastName}
+  :Phone Number: ${printable.phoneNumber}
+  :Registration Number: ${printable.registrationNumber}
+  :Social Security Number: ${printable.socialSecurityNumber}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2Employer.ts
+++ b/src/product/fr/payslip/payslipV2Employer.ts
@@ -1,0 +1,99 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about the employer.
+ */
+export class PayslipV2Employer {
+  /** The address of the employer. */
+  address: string | undefined;
+  /** The company ID of the employer. */
+  companyId: string | undefined;
+  /** The site of the company. */
+  companySite: string | undefined;
+  /** The NAF code of the employer. */
+  nafCode: string | undefined;
+  /** The name of the employer. */
+  name: string | undefined;
+  /** The phone number of the employer. */
+  phoneNumber: string | undefined;
+  /** The URSSAF number of the employer. */
+  urssafNumber: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.address = prediction["address"];
+    this.companyId = prediction["company_id"];
+    this.companySite = prediction["company_site"];
+    this.nafCode = prediction["naf_code"];
+    this.name = prediction["name"];
+    this.phoneNumber = prediction["phone_number"];
+    this.urssafNumber = prediction["urssaf_number"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      address: this.address ?? "",
+      companyId: this.companyId ?? "",
+      companySite: this.companySite ?? "",
+      nafCode: this.nafCode ?? "",
+      name: this.name ?? "",
+      phoneNumber: this.phoneNumber ?? "",
+      urssafNumber: this.urssafNumber ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Address: " +
+      printable.address +
+      ", Company ID: " +
+      printable.companyId +
+      ", Company Site: " +
+      printable.companySite +
+      ", NAF Code: " +
+      printable.nafCode +
+      ", Name: " +
+      printable.name +
+      ", Phone Number: " +
+      printable.phoneNumber +
+      ", URSSAF Number: " +
+      printable.urssafNumber
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Address: ${printable.address}
+  :Company ID: ${printable.companyId}
+  :Company Site: ${printable.companySite}
+  :NAF Code: ${printable.nafCode}
+  :Name: ${printable.name}
+  :Phone Number: ${printable.phoneNumber}
+  :URSSAF Number: ${printable.urssafNumber}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2Employer.ts
+++ b/src/product/fr/payslip/payslipV2Employer.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2Employer.ts
+++ b/src/product/fr/payslip/payslipV2Employer.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,19 +7,19 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2Employer {
   /** The address of the employer. */
-  address: string | undefined;
+  address: string | null;
   /** The company ID of the employer. */
-  companyId: string | undefined;
+  companyId: string | null;
   /** The site of the company. */
-  companySite: string | undefined;
+  companySite: string | null;
   /** The NAF code of the employer. */
-  nafCode: string | undefined;
+  nafCode: string | null;
   /** The name of the employer. */
-  name: string | undefined;
+  name: string | null;
   /** The phone number of the employer. */
-  phoneNumber: string | undefined;
+  phoneNumber: string | null;
   /** The URSSAF number of the employer. */
-  urssafNumber: string | undefined;
+  urssafNumber: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/payslip/payslipV2Employment.ts
+++ b/src/product/fr/payslip/payslipV2Employment.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,17 +8,17 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2Employment {
   /** The category of the employment. */
-  category: string | undefined;
+  category: string | null;
   /** The coefficient of the employment. */
-  coefficient: number | undefined;
+  coefficient: number | null;
   /** The collective agreement of the employment. */
-  collectiveAgreement: string | undefined;
+  collectiveAgreement: string | null;
   /** The job title of the employee. */
-  jobTitle: string | undefined;
+  jobTitle: string | null;
   /** The position level of the employment. */
-  positionLevel: string | undefined;
+  positionLevel: string | null;
   /** The start date of the employment. */
-  startDate: string | undefined;
+  startDate: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -31,8 +31,14 @@ export class PayslipV2Employment {
 
   constructor({ prediction = {} }: StringDict) {
     this.category = prediction["category"];
-    if (prediction["coefficient"] && !isNaN(prediction["coefficient"])) {
-      this.coefficient = +parseFloat(prediction["coefficient"]).toFixed(3);
+    if (
+      prediction["coefficient"] !== undefined &&
+      prediction["coefficient"] !== null &&
+      !isNaN(prediction["coefficient"])
+    ) {
+      this.coefficient = +parseFloat(prediction["coefficient"]);
+    } else {
+      this.coefficient = null;
     }
     this.collectiveAgreement = prediction["collective_agreement"];
     this.jobTitle = prediction["job_title"];

--- a/src/product/fr/payslip/payslipV2Employment.ts
+++ b/src/product/fr/payslip/payslipV2Employment.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2Employment.ts
+++ b/src/product/fr/payslip/payslipV2Employment.ts
@@ -1,0 +1,96 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about the employment.
+ */
+export class PayslipV2Employment {
+  /** The category of the employment. */
+  category: string | undefined;
+  /** The coefficient of the employment. */
+  coefficient: number | undefined;
+  /** The collective agreement of the employment. */
+  collectiveAgreement: string | undefined;
+  /** The job title of the employee. */
+  jobTitle: string | undefined;
+  /** The position level of the employment. */
+  positionLevel: string | undefined;
+  /** The start date of the employment. */
+  startDate: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.category = prediction["category"];
+    if (prediction["coefficient"] && !isNaN(prediction["coefficient"])) {
+      this.coefficient = +parseFloat(prediction["coefficient"]).toFixed(3);
+    }
+    this.collectiveAgreement = prediction["collective_agreement"];
+    this.jobTitle = prediction["job_title"];
+    this.positionLevel = prediction["position_level"];
+    this.startDate = prediction["start_date"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      category: this.category ?? "",
+      coefficient:
+        this.coefficient !== undefined ? floatToString(this.coefficient) : "",
+      collectiveAgreement: this.collectiveAgreement ?? "",
+      jobTitle: this.jobTitle ?? "",
+      positionLevel: this.positionLevel ?? "",
+      startDate: this.startDate ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Category: " +
+      printable.category +
+      ", Coefficient: " +
+      printable.coefficient +
+      ", Collective Agreement: " +
+      printable.collectiveAgreement +
+      ", Job Title: " +
+      printable.jobTitle +
+      ", Position Level: " +
+      printable.positionLevel +
+      ", Start Date: " +
+      printable.startDate
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Category: ${printable.category}
+  :Coefficient: ${printable.coefficient}
+  :Collective Agreement: ${printable.collectiveAgreement}
+  :Job Title: ${printable.jobTitle}
+  :Position Level: ${printable.positionLevel}
+  :Start Date: ${printable.startDate}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2PayDetail.ts
+++ b/src/product/fr/payslip/payslipV2PayDetail.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2PayDetail.ts
+++ b/src/product/fr/payslip/payslipV2PayDetail.ts
@@ -1,0 +1,150 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Detailed information about the pay.
+ */
+export class PayslipV2PayDetail {
+  /** The gross salary of the employee. */
+  grossSalary: number | undefined;
+  /** The year-to-date gross salary of the employee. */
+  grossSalaryYtd: number | undefined;
+  /** The income tax rate of the employee. */
+  incomeTaxRate: number | undefined;
+  /** The income tax withheld from the employee's pay. */
+  incomeTaxWithheld: number | undefined;
+  /** The net paid amount of the employee. */
+  netPaid: number | undefined;
+  /** The net paid amount before tax of the employee. */
+  netPaidBeforeTax: number | undefined;
+  /** The net taxable amount of the employee. */
+  netTaxable: number | undefined;
+  /** The year-to-date net taxable amount of the employee. */
+  netTaxableYtd: number | undefined;
+  /** The total cost to the employer. */
+  totalCostEmployer: number | undefined;
+  /** The total taxes and deductions of the employee. */
+  totalTaxesAndDeductions: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["gross_salary"] && !isNaN(prediction["gross_salary"])) {
+      this.grossSalary = +parseFloat(prediction["gross_salary"]).toFixed(3);
+    }
+    if (prediction["gross_salary_ytd"] && !isNaN(prediction["gross_salary_ytd"])) {
+      this.grossSalaryYtd = +parseFloat(prediction["gross_salary_ytd"]).toFixed(3);
+    }
+    if (prediction["income_tax_rate"] && !isNaN(prediction["income_tax_rate"])) {
+      this.incomeTaxRate = +parseFloat(prediction["income_tax_rate"]).toFixed(3);
+    }
+    if (prediction["income_tax_withheld"] && !isNaN(prediction["income_tax_withheld"])) {
+      this.incomeTaxWithheld = +parseFloat(prediction["income_tax_withheld"]).toFixed(3);
+    }
+    if (prediction["net_paid"] && !isNaN(prediction["net_paid"])) {
+      this.netPaid = +parseFloat(prediction["net_paid"]).toFixed(3);
+    }
+    if (prediction["net_paid_before_tax"] && !isNaN(prediction["net_paid_before_tax"])) {
+      this.netPaidBeforeTax = +parseFloat(prediction["net_paid_before_tax"]).toFixed(3);
+    }
+    if (prediction["net_taxable"] && !isNaN(prediction["net_taxable"])) {
+      this.netTaxable = +parseFloat(prediction["net_taxable"]).toFixed(3);
+    }
+    if (prediction["net_taxable_ytd"] && !isNaN(prediction["net_taxable_ytd"])) {
+      this.netTaxableYtd = +parseFloat(prediction["net_taxable_ytd"]).toFixed(3);
+    }
+    if (prediction["total_cost_employer"] && !isNaN(prediction["total_cost_employer"])) {
+      this.totalCostEmployer = +parseFloat(prediction["total_cost_employer"]).toFixed(3);
+    }
+    if (prediction["total_taxes_and_deductions"] && !isNaN(prediction["total_taxes_and_deductions"])) {
+      this.totalTaxesAndDeductions = +parseFloat(prediction["total_taxes_and_deductions"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      grossSalary:
+        this.grossSalary !== undefined ? floatToString(this.grossSalary) : "",
+      grossSalaryYtd:
+        this.grossSalaryYtd !== undefined ? floatToString(this.grossSalaryYtd) : "",
+      incomeTaxRate:
+        this.incomeTaxRate !== undefined ? floatToString(this.incomeTaxRate) : "",
+      incomeTaxWithheld:
+        this.incomeTaxWithheld !== undefined ? floatToString(this.incomeTaxWithheld) : "",
+      netPaid: this.netPaid !== undefined ? floatToString(this.netPaid) : "",
+      netPaidBeforeTax:
+        this.netPaidBeforeTax !== undefined ? floatToString(this.netPaidBeforeTax) : "",
+      netTaxable:
+        this.netTaxable !== undefined ? floatToString(this.netTaxable) : "",
+      netTaxableYtd:
+        this.netTaxableYtd !== undefined ? floatToString(this.netTaxableYtd) : "",
+      totalCostEmployer:
+        this.totalCostEmployer !== undefined ? floatToString(this.totalCostEmployer) : "",
+      totalTaxesAndDeductions:
+        this.totalTaxesAndDeductions !== undefined ? floatToString(this.totalTaxesAndDeductions) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Gross Salary: " +
+      printable.grossSalary +
+      ", Gross Salary YTD: " +
+      printable.grossSalaryYtd +
+      ", Income Tax Rate: " +
+      printable.incomeTaxRate +
+      ", Income Tax Withheld: " +
+      printable.incomeTaxWithheld +
+      ", Net Paid: " +
+      printable.netPaid +
+      ", Net Paid Before Tax: " +
+      printable.netPaidBeforeTax +
+      ", Net Taxable: " +
+      printable.netTaxable +
+      ", Net Taxable YTD: " +
+      printable.netTaxableYtd +
+      ", Total Cost Employer: " +
+      printable.totalCostEmployer +
+      ", Total Taxes and Deductions: " +
+      printable.totalTaxesAndDeductions
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Gross Salary: ${printable.grossSalary}
+  :Gross Salary YTD: ${printable.grossSalaryYtd}
+  :Income Tax Rate: ${printable.incomeTaxRate}
+  :Income Tax Withheld: ${printable.incomeTaxWithheld}
+  :Net Paid: ${printable.netPaid}
+  :Net Paid Before Tax: ${printable.netPaidBeforeTax}
+  :Net Taxable: ${printable.netTaxable}
+  :Net Taxable YTD: ${printable.netTaxableYtd}
+  :Total Cost Employer: ${printable.totalCostEmployer}
+  :Total Taxes and Deductions: ${printable.totalTaxesAndDeductions}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2PayDetail.ts
+++ b/src/product/fr/payslip/payslipV2PayDetail.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,25 +8,25 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2PayDetail {
   /** The gross salary of the employee. */
-  grossSalary: number | undefined;
+  grossSalary: number | null;
   /** The year-to-date gross salary of the employee. */
-  grossSalaryYtd: number | undefined;
+  grossSalaryYtd: number | null;
   /** The income tax rate of the employee. */
-  incomeTaxRate: number | undefined;
+  incomeTaxRate: number | null;
   /** The income tax withheld from the employee's pay. */
-  incomeTaxWithheld: number | undefined;
+  incomeTaxWithheld: number | null;
   /** The net paid amount of the employee. */
-  netPaid: number | undefined;
+  netPaid: number | null;
   /** The net paid amount before tax of the employee. */
-  netPaidBeforeTax: number | undefined;
+  netPaidBeforeTax: number | null;
   /** The net taxable amount of the employee. */
-  netTaxable: number | undefined;
+  netTaxable: number | null;
   /** The year-to-date net taxable amount of the employee. */
-  netTaxableYtd: number | undefined;
+  netTaxableYtd: number | null;
   /** The total cost to the employer. */
-  totalCostEmployer: number | undefined;
+  totalCostEmployer: number | null;
   /** The total taxes and deductions of the employee. */
-  totalTaxesAndDeductions: number | undefined;
+  totalTaxesAndDeductions: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -38,35 +38,95 @@ export class PayslipV2PayDetail {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["gross_salary"] && !isNaN(prediction["gross_salary"])) {
-      this.grossSalary = +parseFloat(prediction["gross_salary"]).toFixed(3);
+    if (
+      prediction["gross_salary"] !== undefined &&
+      prediction["gross_salary"] !== null &&
+      !isNaN(prediction["gross_salary"])
+    ) {
+      this.grossSalary = +parseFloat(prediction["gross_salary"]);
+    } else {
+      this.grossSalary = null;
     }
-    if (prediction["gross_salary_ytd"] && !isNaN(prediction["gross_salary_ytd"])) {
-      this.grossSalaryYtd = +parseFloat(prediction["gross_salary_ytd"]).toFixed(3);
+    if (
+      prediction["gross_salary_ytd"] !== undefined &&
+      prediction["gross_salary_ytd"] !== null &&
+      !isNaN(prediction["gross_salary_ytd"])
+    ) {
+      this.grossSalaryYtd = +parseFloat(prediction["gross_salary_ytd"]);
+    } else {
+      this.grossSalaryYtd = null;
     }
-    if (prediction["income_tax_rate"] && !isNaN(prediction["income_tax_rate"])) {
-      this.incomeTaxRate = +parseFloat(prediction["income_tax_rate"]).toFixed(3);
+    if (
+      prediction["income_tax_rate"] !== undefined &&
+      prediction["income_tax_rate"] !== null &&
+      !isNaN(prediction["income_tax_rate"])
+    ) {
+      this.incomeTaxRate = +parseFloat(prediction["income_tax_rate"]);
+    } else {
+      this.incomeTaxRate = null;
     }
-    if (prediction["income_tax_withheld"] && !isNaN(prediction["income_tax_withheld"])) {
-      this.incomeTaxWithheld = +parseFloat(prediction["income_tax_withheld"]).toFixed(3);
+    if (
+      prediction["income_tax_withheld"] !== undefined &&
+      prediction["income_tax_withheld"] !== null &&
+      !isNaN(prediction["income_tax_withheld"])
+    ) {
+      this.incomeTaxWithheld = +parseFloat(prediction["income_tax_withheld"]);
+    } else {
+      this.incomeTaxWithheld = null;
     }
-    if (prediction["net_paid"] && !isNaN(prediction["net_paid"])) {
-      this.netPaid = +parseFloat(prediction["net_paid"]).toFixed(3);
+    if (
+      prediction["net_paid"] !== undefined &&
+      prediction["net_paid"] !== null &&
+      !isNaN(prediction["net_paid"])
+    ) {
+      this.netPaid = +parseFloat(prediction["net_paid"]);
+    } else {
+      this.netPaid = null;
     }
-    if (prediction["net_paid_before_tax"] && !isNaN(prediction["net_paid_before_tax"])) {
-      this.netPaidBeforeTax = +parseFloat(prediction["net_paid_before_tax"]).toFixed(3);
+    if (
+      prediction["net_paid_before_tax"] !== undefined &&
+      prediction["net_paid_before_tax"] !== null &&
+      !isNaN(prediction["net_paid_before_tax"])
+    ) {
+      this.netPaidBeforeTax = +parseFloat(prediction["net_paid_before_tax"]);
+    } else {
+      this.netPaidBeforeTax = null;
     }
-    if (prediction["net_taxable"] && !isNaN(prediction["net_taxable"])) {
-      this.netTaxable = +parseFloat(prediction["net_taxable"]).toFixed(3);
+    if (
+      prediction["net_taxable"] !== undefined &&
+      prediction["net_taxable"] !== null &&
+      !isNaN(prediction["net_taxable"])
+    ) {
+      this.netTaxable = +parseFloat(prediction["net_taxable"]);
+    } else {
+      this.netTaxable = null;
     }
-    if (prediction["net_taxable_ytd"] && !isNaN(prediction["net_taxable_ytd"])) {
-      this.netTaxableYtd = +parseFloat(prediction["net_taxable_ytd"]).toFixed(3);
+    if (
+      prediction["net_taxable_ytd"] !== undefined &&
+      prediction["net_taxable_ytd"] !== null &&
+      !isNaN(prediction["net_taxable_ytd"])
+    ) {
+      this.netTaxableYtd = +parseFloat(prediction["net_taxable_ytd"]);
+    } else {
+      this.netTaxableYtd = null;
     }
-    if (prediction["total_cost_employer"] && !isNaN(prediction["total_cost_employer"])) {
-      this.totalCostEmployer = +parseFloat(prediction["total_cost_employer"]).toFixed(3);
+    if (
+      prediction["total_cost_employer"] !== undefined &&
+      prediction["total_cost_employer"] !== null &&
+      !isNaN(prediction["total_cost_employer"])
+    ) {
+      this.totalCostEmployer = +parseFloat(prediction["total_cost_employer"]);
+    } else {
+      this.totalCostEmployer = null;
     }
-    if (prediction["total_taxes_and_deductions"] && !isNaN(prediction["total_taxes_and_deductions"])) {
-      this.totalTaxesAndDeductions = +parseFloat(prediction["total_taxes_and_deductions"]).toFixed(3);
+    if (
+      prediction["total_taxes_and_deductions"] !== undefined &&
+      prediction["total_taxes_and_deductions"] !== null &&
+      !isNaN(prediction["total_taxes_and_deductions"])
+    ) {
+      this.totalTaxesAndDeductions = +parseFloat(prediction["total_taxes_and_deductions"]);
+    } else {
+      this.totalTaxesAndDeductions = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/fr/payslip/payslipV2PayPeriod.ts
+++ b/src/product/fr/payslip/payslipV2PayPeriod.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2PayPeriod.ts
+++ b/src/product/fr/payslip/payslipV2PayPeriod.ts
@@ -1,4 +1,4 @@
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -7,15 +7,15 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2PayPeriod {
   /** The end date of the pay period. */
-  endDate: string | undefined;
+  endDate: string | null;
   /** The month of the pay period. */
-  month: string | undefined;
+  month: string | null;
   /** The date of payment for the pay period. */
-  paymentDate: string | undefined;
+  paymentDate: string | null;
   /** The start date of the pay period. */
-  startDate: string | undefined;
+  startDate: string | null;
   /** The year of the pay period. */
-  year: string | undefined;
+  year: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */

--- a/src/product/fr/payslip/payslipV2PayPeriod.ts
+++ b/src/product/fr/payslip/payslipV2PayPeriod.ts
@@ -1,0 +1,85 @@
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about the pay period.
+ */
+export class PayslipV2PayPeriod {
+  /** The end date of the pay period. */
+  endDate: string | undefined;
+  /** The month of the pay period. */
+  month: string | undefined;
+  /** The date of payment for the pay period. */
+  paymentDate: string | undefined;
+  /** The start date of the pay period. */
+  startDate: string | undefined;
+  /** The year of the pay period. */
+  year: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    this.endDate = prediction["end_date"];
+    this.month = prediction["month"];
+    this.paymentDate = prediction["payment_date"];
+    this.startDate = prediction["start_date"];
+    this.year = prediction["year"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      endDate: this.endDate ?? "",
+      month: this.month ?? "",
+      paymentDate: this.paymentDate ?? "",
+      startDate: this.startDate ?? "",
+      year: this.year ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "End Date: " +
+      printable.endDate +
+      ", Month: " +
+      printable.month +
+      ", Payment Date: " +
+      printable.paymentDate +
+      ", Start Date: " +
+      printable.startDate +
+      ", Year: " +
+      printable.year
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :End Date: ${printable.endDate}
+  :Month: ${printable.month}
+  :Payment Date: ${printable.paymentDate}
+  :Start Date: ${printable.startDate}
+  :Year: ${printable.year}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2Pto.ts
+++ b/src/product/fr/payslip/payslipV2Pto.ts
@@ -1,0 +1,81 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Information about paid time off.
+ */
+export class PayslipV2Pto {
+  /** The amount of paid time off accrued in this period. */
+  accruedThisPeriod: number | undefined;
+  /** The balance of paid time off at the end of the period. */
+  balanceEndOfPeriod: number | undefined;
+  /** The amount of paid time off used in this period. */
+  usedThisPeriod: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["accrued_this_period"] && !isNaN(prediction["accrued_this_period"])) {
+      this.accruedThisPeriod = +parseFloat(prediction["accrued_this_period"]).toFixed(3);
+    }
+    if (prediction["balance_end_of_period"] && !isNaN(prediction["balance_end_of_period"])) {
+      this.balanceEndOfPeriod = +parseFloat(prediction["balance_end_of_period"]).toFixed(3);
+    }
+    if (prediction["used_this_period"] && !isNaN(prediction["used_this_period"])) {
+      this.usedThisPeriod = +parseFloat(prediction["used_this_period"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      accruedThisPeriod:
+        this.accruedThisPeriod !== undefined ? floatToString(this.accruedThisPeriod) : "",
+      balanceEndOfPeriod:
+        this.balanceEndOfPeriod !== undefined ? floatToString(this.balanceEndOfPeriod) : "",
+      usedThisPeriod:
+        this.usedThisPeriod !== undefined ? floatToString(this.usedThisPeriod) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Accrued This Period: " +
+      printable.accruedThisPeriod +
+      ", Balance End of Period: " +
+      printable.balanceEndOfPeriod +
+      ", Used This Period: " +
+      printable.usedThisPeriod
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Accrued This Period: ${printable.accruedThisPeriod}
+  :Balance End of Period: ${printable.balanceEndOfPeriod}
+  :Used This Period: ${printable.usedThisPeriod}`.trimEnd();
+  }
+}

--- a/src/product/fr/payslip/payslipV2Pto.ts
+++ b/src/product/fr/payslip/payslipV2Pto.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2Pto {
   /** The amount of paid time off accrued in this period. */
-  accruedThisPeriod: number | undefined;
+  accruedThisPeriod: number | null;
   /** The balance of paid time off at the end of the period. */
-  balanceEndOfPeriod: number | undefined;
+  balanceEndOfPeriod: number | null;
   /** The amount of paid time off used in this period. */
-  usedThisPeriod: number | undefined;
+  usedThisPeriod: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class PayslipV2Pto {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["accrued_this_period"] && !isNaN(prediction["accrued_this_period"])) {
-      this.accruedThisPeriod = +parseFloat(prediction["accrued_this_period"]).toFixed(3);
+    if (
+      prediction["accrued_this_period"] !== undefined &&
+      prediction["accrued_this_period"] !== null &&
+      !isNaN(prediction["accrued_this_period"])
+    ) {
+      this.accruedThisPeriod = +parseFloat(prediction["accrued_this_period"]);
+    } else {
+      this.accruedThisPeriod = null;
     }
-    if (prediction["balance_end_of_period"] && !isNaN(prediction["balance_end_of_period"])) {
-      this.balanceEndOfPeriod = +parseFloat(prediction["balance_end_of_period"]).toFixed(3);
+    if (
+      prediction["balance_end_of_period"] !== undefined &&
+      prediction["balance_end_of_period"] !== null &&
+      !isNaN(prediction["balance_end_of_period"])
+    ) {
+      this.balanceEndOfPeriod = +parseFloat(prediction["balance_end_of_period"]);
+    } else {
+      this.balanceEndOfPeriod = null;
     }
-    if (prediction["used_this_period"] && !isNaN(prediction["used_this_period"])) {
-      this.usedThisPeriod = +parseFloat(prediction["used_this_period"]).toFixed(3);
+    if (
+      prediction["used_this_period"] !== undefined &&
+      prediction["used_this_period"] !== null &&
+      !isNaN(prediction["used_this_period"])
+    ) {
+      this.usedThisPeriod = +parseFloat(prediction["used_this_period"]);
+    } else {
+      this.usedThisPeriod = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/fr/payslip/payslipV2Pto.ts
+++ b/src/product/fr/payslip/payslipV2Pto.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 

--- a/src/product/fr/payslip/payslipV2SalaryDetail.ts
+++ b/src/product/fr/payslip/payslipV2SalaryDetail.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,13 +7,13 @@ import { Polygon } from "../../../geometry";
  */
 export class PayslipV2SalaryDetail {
   /** The amount of the earnings. */
-  amount: number | undefined;
+  amount: number | null;
   /** The base value of the earnings. */
-  base: number | undefined;
+  base: number | null;
   /** The description of the earnings. */
-  description: string | undefined;
+  description: string | null;
   /** The rate of the earnings. */
-  rate: number | undefined;
+  rate: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -26,15 +25,33 @@ export class PayslipV2SalaryDetail {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["amount"] && !isNaN(prediction["amount"])) {
-      this.amount = +parseFloat(prediction["amount"]).toFixed(3);
+    if (
+      prediction["amount"] !== undefined &&
+      prediction["amount"] !== null &&
+      !isNaN(prediction["amount"])
+    ) {
+      this.amount = +parseFloat(prediction["amount"]);
+    } else {
+      this.amount = null;
     }
-    if (prediction["base"] && !isNaN(prediction["base"])) {
-      this.base = +parseFloat(prediction["base"]).toFixed(3);
+    if (
+      prediction["base"] !== undefined &&
+      prediction["base"] !== null &&
+      !isNaN(prediction["base"])
+    ) {
+      this.base = +parseFloat(prediction["base"]);
+    } else {
+      this.base = null;
     }
     this.description = prediction["description"];
-    if (prediction["rate"] && !isNaN(prediction["rate"])) {
-      this.rate = +parseFloat(prediction["rate"]).toFixed(3);
+    if (
+      prediction["rate"] !== undefined &&
+      prediction["rate"] !== null &&
+      !isNaN(prediction["rate"])
+    ) {
+      this.rate = +parseFloat(prediction["rate"]);
+    } else {
+      this.rate = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -52,8 +69,8 @@ export class PayslipV2SalaryDetail {
       base: this.base !== undefined ? floatToString(this.base) : "",
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       rate: this.rate !== undefined ? floatToString(this.rate) : "",
     };
@@ -84,11 +101,11 @@ export class PayslipV2SalaryDetail {
       "| " +
       printable.amount.padEnd(12) +
       " | " +
-      printable.base.padEnd(8) +
+      printable.base.padEnd(9) +
       " | " +
       printable.description.padEnd(36) +
       " | " +
-      printable.rate.padEnd(8) +
+      printable.rate.padEnd(9) +
       " |"
     );
   }

--- a/src/product/fr/payslip/payslipV2SalaryDetail.ts
+++ b/src/product/fr/payslip/payslipV2SalaryDetail.ts
@@ -92,6 +92,7 @@ export class PayslipV2SalaryDetail {
       printable.rate
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/fr/payslip/payslipV2SalaryDetail.ts
+++ b/src/product/fr/payslip/payslipV2SalaryDetail.ts
@@ -50,9 +50,9 @@ export class PayslipV2SalaryDetail {
       amount: this.amount !== undefined ? floatToString(this.amount) : "",
       base: this.base !== undefined ? floatToString(this.base) : "",
       description: this.description ?
-        this.description.length <= 11 ?
+        this.description.length <= 36 ?
           this.description :
-          this.description.slice(0, 8) + "..." :
+          this.description.slice(0, 33) + "..." :
         "",
       rate: this.rate !== undefined ? floatToString(this.rate) : "",
     };
@@ -81,13 +81,13 @@ export class PayslipV2SalaryDetail {
     const printable = this.#printableValues();
     return (
       "| " +
-      printable.amount.padEnd(6) +
+      printable.amount.padEnd(12) +
       " | " +
-      printable.base.padEnd(4) +
+      printable.base.padEnd(8) +
       " | " +
-      printable.description.padEnd(11) +
+      printable.description.padEnd(36) +
       " | " +
-      printable.rate.padEnd(4) +
+      printable.rate.padEnd(8) +
       " |"
     );
   }

--- a/src/product/fr/payslip/payslipV2SalaryDetail.ts
+++ b/src/product/fr/payslip/payslipV2SalaryDetail.ts
@@ -1,0 +1,94 @@
+import { floatToString } from "../../../parsing/standard";
+import { StringDict } from "../../../parsing/common";
+import { Polygon } from "../../../geometry";
+
+/**
+ * Detailed information about the earnings.
+ */
+export class PayslipV2SalaryDetail {
+  /** The amount of the earnings. */
+  amount: number | undefined;
+  /** The base value of the earnings. */
+  base: number | undefined;
+  /** The description of the earnings. */
+  description: string | undefined;
+  /** The rate of the earnings. */
+  rate: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["amount"] && !isNaN(prediction["amount"])) {
+      this.amount = +parseFloat(prediction["amount"]).toFixed(3);
+    }
+    if (prediction["base"] && !isNaN(prediction["base"])) {
+      this.base = +parseFloat(prediction["base"]).toFixed(3);
+    }
+    this.description = prediction["description"];
+    if (prediction["rate"] && !isNaN(prediction["rate"])) {
+      this.rate = +parseFloat(prediction["rate"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      amount: this.amount !== undefined ? floatToString(this.amount) : "",
+      base: this.base !== undefined ? floatToString(this.base) : "",
+      description: this.description ?
+        this.description.length <= 11 ?
+          this.description :
+          this.description.slice(0, 8) + "..." :
+        "",
+      rate: this.rate !== undefined ? floatToString(this.rate) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Amount: " +
+      printable.amount +
+      ", Base: " +
+      printable.base +
+      ", Description: " +
+      printable.description +
+      ", Rate: " +
+      printable.rate
+    );
+  }
+  /**
+   * Output in a format suitable for inclusion in an rST table.
+   */
+  toTableLine(): string {
+    const printable = this.#printableValues();
+    return (
+      "| " +
+      printable.amount.padEnd(6) +
+      " | " +
+      printable.base.padEnd(4) +
+      " | " +
+      printable.description.padEnd(11) +
+      " | " +
+      printable.rate.padEnd(4) +
+      " |"
+    );
+  }
+}

--- a/src/product/fr/payslip/payslipV2SalaryDetail.ts
+++ b/src/product/fr/payslip/payslipV2SalaryDetail.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -51,8 +52,8 @@ export class PayslipV2SalaryDetail {
       base: this.base !== undefined ? floatToString(this.base) : "",
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       rate: this.rate !== undefined ? floatToString(this.rate) : "",
     };

--- a/src/product/index.ts
+++ b/src/product/index.ts
@@ -1,4 +1,5 @@
 export { BarcodeReaderV1 } from "./barcodeReader/barcodeReaderV1";
+export { BillOfLadingV1 } from "./billOfLading/billOfLadingV1";
 export { CropperV1 } from "./cropper/cropperV1";
 export { CustomV1 } from "./custom/customV1";
 export { FinancialDocumentV1 } from "./financialDocument/financialDocumentV1";
@@ -8,6 +9,7 @@ export { InternationalIdV2 } from "./internationalId/internationalIdV2";
 export { InvoiceV4 } from "./invoice/invoiceV4";
 export { InvoiceSplitterV1 } from "./invoiceSplitter/invoiceSplitterV1";
 export { MultiReceiptsDetectorV1 } from "./multiReceiptsDetector/multiReceiptsDetectorV1";
+export { NutritionFactsLabelV1 } from "./nutritionFactsLabel/nutritionFactsLabelV1";
 export { PassportV1 } from "./passport/passportV1";
 export { ProofOfAddressV1 } from "./proofOfAddress/proofOfAddressV1";
 export { ReceiptV4 } from "./receipt/receiptV4";

--- a/src/product/internal.ts
+++ b/src/product/internal.ts
@@ -1,4 +1,5 @@
 export * as barcodeReader from "./barcodeReader/internal";
+export * as billOfLading from "./billOfLading/internal";
 export * as cropper from "./cropper/internal";
 export * as custom from "./custom/internal";
 export * as eu from "./eu/internal";
@@ -9,6 +10,7 @@ export * as internationalId from "./internationalId/internal";
 export * as invoice from "./invoice/internal";
 export * as invoiceSplitter from "./invoiceSplitter/internal";
 export * as multiReceiptsDetector from "./multiReceiptsDetector/internal";
+export * as nutritionFactsLabel from "./nutritionFactsLabel/internal";
 export * as passport from "./passport/internal";
 export * as proofOfAddress from "./proofOfAddress/internal";
 export * as receipt from "./receipt/internal";

--- a/src/product/invoice/invoiceV4LineItem.ts
+++ b/src/product/invoice/invoiceV4LineItem.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -65,13 +66,13 @@ export class InvoiceV4LineItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       productCode: this.productCode ?
         this.productCode.length <= 12 ?
-          this.productCode :
-          this.productCode.slice(0, 9) + "..." :
+          cleanSpaces(this.productCode) :
+          cleanSpaces(this.productCode).slice(0, 9) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       taxAmount: this.taxAmount !== undefined ? floatToString(this.taxAmount) : "",
@@ -80,8 +81,8 @@ export class InvoiceV4LineItem {
         this.totalAmount !== undefined ? floatToString(this.totalAmount) : "",
       unitMeasure: this.unitMeasure ?
         this.unitMeasure.length <= 15 ?
-          this.unitMeasure :
-          this.unitMeasure.slice(0, 12) + "..." :
+          cleanSpaces(this.unitMeasure) :
+          cleanSpaces(this.unitMeasure).slice(0, 12) + "..." :
         "",
       unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
     };

--- a/src/product/invoice/invoiceV4LineItem.ts
+++ b/src/product/invoice/invoiceV4LineItem.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,21 +7,21 @@ import { Polygon } from "../../geometry";
  */
 export class InvoiceV4LineItem {
   /** The item description. */
-  description: string | undefined;
+  description: string | null;
   /** The product code referring to the item. */
-  productCode: string | undefined;
+  productCode: string | null;
   /** The item quantity */
-  quantity: number | undefined;
+  quantity: number | null;
   /** The item tax amount. */
-  taxAmount: number | undefined;
+  taxAmount: number | null;
   /** The item tax rate in percentage. */
-  taxRate: number | undefined;
+  taxRate: number | null;
   /** The item total amount. */
-  totalAmount: number | undefined;
+  totalAmount: number | null;
   /** The item unit of measure. */
-  unitMeasure: string | undefined;
+  unitMeasure: string | null;
   /** The item unit price. */
-  unitPrice: number | undefined;
+  unitPrice: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -36,21 +35,51 @@ export class InvoiceV4LineItem {
   constructor({ prediction = {} }: StringDict) {
     this.description = prediction["description"];
     this.productCode = prediction["product_code"];
-    if (prediction["quantity"] && !isNaN(prediction["quantity"])) {
-      this.quantity = +parseFloat(prediction["quantity"]).toFixed(3);
+    if (
+      prediction["quantity"] !== undefined &&
+      prediction["quantity"] !== null &&
+      !isNaN(prediction["quantity"])
+    ) {
+      this.quantity = +parseFloat(prediction["quantity"]);
+    } else {
+      this.quantity = null;
     }
-    if (prediction["tax_amount"] && !isNaN(prediction["tax_amount"])) {
-      this.taxAmount = +parseFloat(prediction["tax_amount"]).toFixed(3);
+    if (
+      prediction["tax_amount"] !== undefined &&
+      prediction["tax_amount"] !== null &&
+      !isNaN(prediction["tax_amount"])
+    ) {
+      this.taxAmount = +parseFloat(prediction["tax_amount"]);
+    } else {
+      this.taxAmount = null;
     }
-    if (prediction["tax_rate"] && !isNaN(prediction["tax_rate"])) {
-      this.taxRate = +parseFloat(prediction["tax_rate"]).toFixed(3);
+    if (
+      prediction["tax_rate"] !== undefined &&
+      prediction["tax_rate"] !== null &&
+      !isNaN(prediction["tax_rate"])
+    ) {
+      this.taxRate = +parseFloat(prediction["tax_rate"]);
+    } else {
+      this.taxRate = null;
     }
-    if (prediction["total_amount"] && !isNaN(prediction["total_amount"])) {
-      this.totalAmount = +parseFloat(prediction["total_amount"]).toFixed(3);
+    if (
+      prediction["total_amount"] !== undefined &&
+      prediction["total_amount"] !== null &&
+      !isNaN(prediction["total_amount"])
+    ) {
+      this.totalAmount = +parseFloat(prediction["total_amount"]);
+    } else {
+      this.totalAmount = null;
     }
     this.unitMeasure = prediction["unit_measure"];
-    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
-      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    if (
+      prediction["unit_price"] !== undefined &&
+      prediction["unit_price"] !== null &&
+      !isNaN(prediction["unit_price"])
+    ) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]);
+    } else {
+      this.unitPrice = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -66,13 +95,13 @@ export class InvoiceV4LineItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       productCode: this.productCode ?
         this.productCode.length <= 12 ?
-          cleanSpaces(this.productCode) :
-          cleanSpaces(this.productCode).slice(0, 9) + "..." :
+          cleanSpecialChars(this.productCode) :
+          cleanSpecialChars(this.productCode).slice(0, 9) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       taxAmount: this.taxAmount !== undefined ? floatToString(this.taxAmount) : "",
@@ -81,8 +110,8 @@ export class InvoiceV4LineItem {
         this.totalAmount !== undefined ? floatToString(this.totalAmount) : "",
       unitMeasure: this.unitMeasure ?
         this.unitMeasure.length <= 15 ?
-          cleanSpaces(this.unitMeasure) :
-          cleanSpaces(this.unitMeasure).slice(0, 12) + "..." :
+          cleanSpecialChars(this.unitMeasure) :
+          cleanSpecialChars(this.unitMeasure).slice(0, 12) + "..." :
         "",
       unitPrice: this.unitPrice !== undefined ? floatToString(this.unitPrice) : "",
     };

--- a/src/product/invoice/invoiceV4LineItem.ts
+++ b/src/product/invoice/invoiceV4LineItem.ts
@@ -141,6 +141,7 @@ export class InvoiceV4LineItem {
       printable.unitPrice
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/nutritionFactsLabel/index.ts
+++ b/src/product/nutritionFactsLabel/index.ts
@@ -1,0 +1,1 @@
+export { NutritionFactsLabelV1 } from "./nutritionFactsLabelV1";

--- a/src/product/nutritionFactsLabel/internal.ts
+++ b/src/product/nutritionFactsLabel/internal.ts
@@ -1,0 +1,15 @@
+export { NutritionFactsLabelV1 } from "./nutritionFactsLabelV1";
+export { NutritionFactsLabelV1AddedSugar } from "./nutritionFactsLabelV1AddedSugar";
+export { NutritionFactsLabelV1Calorie } from "./nutritionFactsLabelV1Calorie";
+export { NutritionFactsLabelV1Cholesterol } from "./nutritionFactsLabelV1Cholesterol";
+export { NutritionFactsLabelV1DietaryFiber } from "./nutritionFactsLabelV1DietaryFiber";
+export { NutritionFactsLabelV1Document } from "./nutritionFactsLabelV1Document";
+export { NutritionFactsLabelV1Nutrient } from "./nutritionFactsLabelV1Nutrient";
+export { NutritionFactsLabelV1Protein } from "./nutritionFactsLabelV1Protein";
+export { NutritionFactsLabelV1SaturatedFat } from "./nutritionFactsLabelV1SaturatedFat";
+export { NutritionFactsLabelV1ServingSize } from "./nutritionFactsLabelV1ServingSize";
+export { NutritionFactsLabelV1Sodium } from "./nutritionFactsLabelV1Sodium";
+export { NutritionFactsLabelV1TotalCarbohydrate } from "./nutritionFactsLabelV1TotalCarbohydrate";
+export { NutritionFactsLabelV1TotalFat } from "./nutritionFactsLabelV1TotalFat";
+export { NutritionFactsLabelV1TotalSugar } from "./nutritionFactsLabelV1TotalSugar";
+export { NutritionFactsLabelV1TransFat } from "./nutritionFactsLabelV1TransFat";

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1.ts
@@ -1,0 +1,34 @@
+import { Inference, StringDict, Page } from "../../parsing/common";
+import { NutritionFactsLabelV1Document } from "./nutritionFactsLabelV1Document";
+
+/**
+ * Nutrition Facts Label API version 1 inference prediction.
+ */
+export class NutritionFactsLabelV1 extends Inference {
+  /** The endpoint's name. */
+  endpointName = "nutrition_facts";
+  /** The endpoint's version. */
+  endpointVersion = "1";
+  /** The document-level prediction. */
+  prediction: NutritionFactsLabelV1Document;
+  /** The document's pages. */
+  pages: Page<NutritionFactsLabelV1Document>[] = [];
+
+  constructor(rawPrediction: StringDict) {
+    super(rawPrediction);
+    this.prediction = new NutritionFactsLabelV1Document(rawPrediction["prediction"]);
+    rawPrediction["pages"].forEach(
+      (page: StringDict) => {
+        if (page.prediction !== undefined && page.prediction !== null &&
+          Object.keys(page.prediction).length > 0) {
+          this.pages.push(new Page(
+            NutritionFactsLabelV1Document,
+            page,
+            page["id"],
+            page["orientation"]
+          ));
+        }
+      }
+    );
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1AddedSugar.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1AddedSugar.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1AddedSugar {
   /** DVs are the recommended amounts of added sugars to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of added sugars per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of added sugars per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1AddedSugar {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1AddedSugar.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1AddedSugar.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of added sugars in the product.
+ */
+export class NutritionFactsLabelV1AddedSugar {
+  /** DVs are the recommended amounts of added sugars to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of added sugars per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of added sugars per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1AddedSugar.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1AddedSugar.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Calorie.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Calorie.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of calories in the product.
+ */
+export class NutritionFactsLabelV1Calorie {
+  /** DVs are the recommended amounts of calories to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of calories per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of calories per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Calorie.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Calorie.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Calorie.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Calorie.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1Calorie {
   /** DVs are the recommended amounts of calories to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of calories per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of calories per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1Calorie {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Cholesterol.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Cholesterol.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1Cholesterol {
   /** DVs are the recommended amounts of cholesterol to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of cholesterol per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of cholesterol per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1Cholesterol {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Cholesterol.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Cholesterol.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of cholesterol in the product.
+ */
+export class NutritionFactsLabelV1Cholesterol {
+  /** DVs are the recommended amounts of cholesterol to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of cholesterol per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of cholesterol per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Cholesterol.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Cholesterol.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1DietaryFiber.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1DietaryFiber.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of dietary fiber in the product.
+ */
+export class NutritionFactsLabelV1DietaryFiber {
+  /** DVs are the recommended amounts of dietary fiber to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of dietary fiber per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of dietary fiber per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1DietaryFiber.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1DietaryFiber.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1DietaryFiber {
   /** DVs are the recommended amounts of dietary fiber to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of dietary fiber per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of dietary fiber per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1DietaryFiber {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1DietaryFiber.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1DietaryFiber.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Document.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Document.ts
@@ -122,10 +122,10 @@ export class NutritionFactsLabelV1Document implements Prediction {
   toString(): string {
     let nutrientsSummary:string = "";
     if (this.nutrients && this.nutrients.length > 0) {
-      const nutrientsColSizes:number[] = [13, 6, 10, 13, 6];
+      const nutrientsColSizes:number[] = [13, 22, 10, 13, 6];
       nutrientsSummary += "\n" + lineSeparator(nutrientsColSizes, "-") + "\n  ";
       nutrientsSummary += "| Daily Value ";
-      nutrientsSummary += "| Name ";
+      nutrientsSummary += "| Name                 ";
       nutrientsSummary += "| Per 100g ";
       nutrientsSummary += "| Per Serving ";
       nutrientsSummary += "| Unit ";

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Document.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Document.ts
@@ -1,0 +1,154 @@
+import {
+  Prediction,
+  StringDict,
+  cleanOutString,lineSeparator,
+} from "../../parsing/common";
+import { NutritionFactsLabelV1ServingSize } from "./nutritionFactsLabelV1ServingSize";
+import { NutritionFactsLabelV1Calorie } from "./nutritionFactsLabelV1Calorie";
+import { NutritionFactsLabelV1TotalFat } from "./nutritionFactsLabelV1TotalFat";
+import { NutritionFactsLabelV1SaturatedFat } from "./nutritionFactsLabelV1SaturatedFat";
+import { NutritionFactsLabelV1TransFat } from "./nutritionFactsLabelV1TransFat";
+import { NutritionFactsLabelV1Cholesterol } from "./nutritionFactsLabelV1Cholesterol";
+import { NutritionFactsLabelV1TotalCarbohydrate } from "./nutritionFactsLabelV1TotalCarbohydrate";
+import { NutritionFactsLabelV1DietaryFiber } from "./nutritionFactsLabelV1DietaryFiber";
+import { NutritionFactsLabelV1TotalSugar } from "./nutritionFactsLabelV1TotalSugar";
+import { NutritionFactsLabelV1AddedSugar } from "./nutritionFactsLabelV1AddedSugar";
+import { NutritionFactsLabelV1Protein } from "./nutritionFactsLabelV1Protein";
+import { NutritionFactsLabelV1Sodium } from "./nutritionFactsLabelV1Sodium";
+import { NutritionFactsLabelV1Nutrient } from "./nutritionFactsLabelV1Nutrient";
+import { AmountField } from "../../parsing/standard";
+
+/**
+ * Nutrition Facts Label API version 1.0 document data.
+ */
+export class NutritionFactsLabelV1Document implements Prediction {
+  /** The amount of added sugars in the product. */
+  addedSugars: NutritionFactsLabelV1AddedSugar;
+  /** The amount of calories in the product. */
+  calories: NutritionFactsLabelV1Calorie;
+  /** The amount of cholesterol in the product. */
+  cholesterol: NutritionFactsLabelV1Cholesterol;
+  /** The amount of dietary fiber in the product. */
+  dietaryFiber: NutritionFactsLabelV1DietaryFiber;
+  /** The amount of nutrients in the product. */
+  nutrients: NutritionFactsLabelV1Nutrient[] = [];
+  /** The amount of protein in the product. */
+  protein: NutritionFactsLabelV1Protein;
+  /** The amount of saturated fat in the product. */
+  saturatedFat: NutritionFactsLabelV1SaturatedFat;
+  /** The number of servings in each box of the product. */
+  servingPerBox: AmountField;
+  /** The size of a single serving of the product. */
+  servingSize: NutritionFactsLabelV1ServingSize;
+  /** The amount of sodium in the product. */
+  sodium: NutritionFactsLabelV1Sodium;
+  /** The total amount of carbohydrates in the product. */
+  totalCarbohydrate: NutritionFactsLabelV1TotalCarbohydrate;
+  /** The total amount of fat in the product. */
+  totalFat: NutritionFactsLabelV1TotalFat;
+  /** The total amount of sugars in the product. */
+  totalSugars: NutritionFactsLabelV1TotalSugar;
+  /** The amount of trans fat in the product. */
+  transFat: NutritionFactsLabelV1TransFat;
+
+  constructor(rawPrediction: StringDict, pageId?: number) {
+    this.addedSugars = new NutritionFactsLabelV1AddedSugar({
+      prediction: rawPrediction["added_sugars"],
+      pageId: pageId,
+    });
+    this.calories = new NutritionFactsLabelV1Calorie({
+      prediction: rawPrediction["calories"],
+      pageId: pageId,
+    });
+    this.cholesterol = new NutritionFactsLabelV1Cholesterol({
+      prediction: rawPrediction["cholesterol"],
+      pageId: pageId,
+    });
+    this.dietaryFiber = new NutritionFactsLabelV1DietaryFiber({
+      prediction: rawPrediction["dietary_fiber"],
+      pageId: pageId,
+    });
+    rawPrediction["nutrients"] &&
+      rawPrediction["nutrients"].map(
+        (itemPrediction: StringDict) =>
+          this.nutrients.push(
+            new NutritionFactsLabelV1Nutrient({
+              prediction: itemPrediction,
+              pageId: pageId,
+            })
+          )
+      );
+    this.protein = new NutritionFactsLabelV1Protein({
+      prediction: rawPrediction["protein"],
+      pageId: pageId,
+    });
+    this.saturatedFat = new NutritionFactsLabelV1SaturatedFat({
+      prediction: rawPrediction["saturated_fat"],
+      pageId: pageId,
+    });
+    this.servingPerBox = new AmountField({
+      prediction: rawPrediction["serving_per_box"],
+      pageId: pageId,
+    });
+    this.servingSize = new NutritionFactsLabelV1ServingSize({
+      prediction: rawPrediction["serving_size"],
+      pageId: pageId,
+    });
+    this.sodium = new NutritionFactsLabelV1Sodium({
+      prediction: rawPrediction["sodium"],
+      pageId: pageId,
+    });
+    this.totalCarbohydrate = new NutritionFactsLabelV1TotalCarbohydrate({
+      prediction: rawPrediction["total_carbohydrate"],
+      pageId: pageId,
+    });
+    this.totalFat = new NutritionFactsLabelV1TotalFat({
+      prediction: rawPrediction["total_fat"],
+      pageId: pageId,
+    });
+    this.totalSugars = new NutritionFactsLabelV1TotalSugar({
+      prediction: rawPrediction["total_sugars"],
+      pageId: pageId,
+    });
+    this.transFat = new NutritionFactsLabelV1TransFat({
+      prediction: rawPrediction["trans_fat"],
+      pageId: pageId,
+    });
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    let nutrientsSummary:string = "";
+    if (this.nutrients && this.nutrients.length > 0) {
+      const nutrientsColSizes:number[] = [13, 6, 10, 13, 6];
+      nutrientsSummary += "\n" + lineSeparator(nutrientsColSizes, "-") + "\n  ";
+      nutrientsSummary += "| Daily Value ";
+      nutrientsSummary += "| Name ";
+      nutrientsSummary += "| Per 100g ";
+      nutrientsSummary += "| Per Serving ";
+      nutrientsSummary += "| Unit ";
+      nutrientsSummary += "|\n" + lineSeparator(nutrientsColSizes, "=");
+      nutrientsSummary += this.nutrients.map(
+        (item) =>
+          "\n  " + item.toTableLine() + "\n" + lineSeparator(nutrientsColSizes, "-")
+      ).join("");
+    }
+    const outStr = `:Serving per Box: ${this.servingPerBox}
+:Serving Size: ${this.servingSize.toFieldList()}
+:Calories: ${this.calories.toFieldList()}
+:Total Fat: ${this.totalFat.toFieldList()}
+:Saturated Fat: ${this.saturatedFat.toFieldList()}
+:Trans Fat: ${this.transFat.toFieldList()}
+:Cholesterol: ${this.cholesterol.toFieldList()}
+:Total Carbohydrate: ${this.totalCarbohydrate.toFieldList()}
+:Dietary Fiber: ${this.dietaryFiber.toFieldList()}
+:Total Sugars: ${this.totalSugars.toFieldList()}
+:Added Sugars: ${this.addedSugars.toFieldList()}
+:Protein: ${this.protein.toFieldList()}
+:sodium: ${this.sodium.toFieldList()}
+:nutrients: ${nutrientsSummary}`.trimEnd();
+    return cleanOutString(outStr);
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
@@ -53,9 +53,9 @@ export class NutritionFactsLabelV1Nutrient {
       dailyValue:
         this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
       name: this.name ?
-        this.name.length <= 4 ?
+        this.name.length <= 20 ?
           this.name :
-          this.name.slice(0, 1) + "..." :
+          this.name.slice(0, 17) + "..." :
         "",
       per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
       perServing:
@@ -95,7 +95,7 @@ export class NutritionFactsLabelV1Nutrient {
       "| " +
       printable.dailyValue.padEnd(11) +
       " | " +
-      printable.name.padEnd(4) +
+      printable.name.padEnd(20) +
       " | " +
       printable.per100G.padEnd(8) +
       " | " +

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -54,16 +55,16 @@ export class NutritionFactsLabelV1Nutrient {
         this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
       name: this.name ?
         this.name.length <= 20 ?
-          this.name :
-          this.name.slice(0, 17) + "..." :
+          cleanSpaces(this.name) :
+          cleanSpaces(this.name).slice(0, 17) + "..." :
         "",
       per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
       perServing:
         this.perServing !== undefined ? floatToString(this.perServing) : "",
       unit: this.unit ?
         this.unit.length <= 4 ?
-          this.unit :
-          this.unit.slice(0, 1) + "..." :
+          cleanSpaces(this.unit) :
+          cleanSpaces(this.unit).slice(0, 1) + "..." :
         "",
     };
   }

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
@@ -1,0 +1,108 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of nutrients in the product.
+ */
+export class NutritionFactsLabelV1Nutrient {
+  /** DVs are the recommended amounts of nutrients to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The name of nutrients of the product. */
+  name: string | undefined;
+  /** The amount of nutrients per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of nutrients per serving of the product. */
+  perServing: number | undefined;
+  /** The unit of measurement for the amount of nutrients. */
+  unit: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    this.name = prediction["name"];
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.unit = prediction["unit"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      name: this.name ?
+        this.name.length <= 4 ?
+          this.name :
+          this.name.slice(0, 1) + "..." :
+        "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+      unit: this.unit ?
+        this.unit.length <= 4 ?
+          this.unit :
+          this.unit.slice(0, 1) + "..." :
+        "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Name: " +
+      printable.name +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing +
+      ", Unit: " +
+      printable.unit
+    );
+  }
+  /**
+   * Output in a format suitable for inclusion in an rST table.
+   */
+  toTableLine(): string {
+    const printable = this.#printableValues();
+    return (
+      "| " +
+      printable.dailyValue.padEnd(11) +
+      " | " +
+      printable.name.padEnd(4) +
+      " | " +
+      printable.per100G.padEnd(8) +
+      " | " +
+      printable.perServing.padEnd(11) +
+      " | " +
+      printable.unit.padEnd(4) +
+      " |"
+    );
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,15 +7,15 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1Nutrient {
   /** DVs are the recommended amounts of nutrients to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The name of nutrients of the product. */
-  name: string | undefined;
+  name: string | null;
   /** The amount of nutrients per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of nutrients per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** The unit of measurement for the amount of nutrients. */
-  unit: string | undefined;
+  unit: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -28,15 +27,33 @@ export class NutritionFactsLabelV1Nutrient {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
     this.name = prediction["name"];
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.unit = prediction["unit"];
     this.pageId = prediction["page_id"];
@@ -55,16 +72,16 @@ export class NutritionFactsLabelV1Nutrient {
         this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
       name: this.name ?
         this.name.length <= 20 ?
-          cleanSpaces(this.name) :
-          cleanSpaces(this.name).slice(0, 17) + "..." :
+          cleanSpecialChars(this.name) :
+          cleanSpecialChars(this.name).slice(0, 17) + "..." :
         "",
       per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
       perServing:
         this.perServing !== undefined ? floatToString(this.perServing) : "",
       unit: this.unit ?
         this.unit.length <= 4 ?
-          cleanSpaces(this.unit) :
-          cleanSpaces(this.unit).slice(0, 1) + "..." :
+          cleanSpecialChars(this.unit) :
+          cleanSpecialChars(this.unit).slice(0, 1) + "..." :
         "",
     };
   }

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Nutrient.ts
@@ -104,6 +104,7 @@ export class NutritionFactsLabelV1Nutrient {
       printable.unit
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Protein.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Protein.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of protein in the product.
+ */
+export class NutritionFactsLabelV1Protein {
+  /** DVs are the recommended amounts of protein to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of protein per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of protein per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Protein.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Protein.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1Protein {
   /** DVs are the recommended amounts of protein to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of protein per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of protein per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1Protein {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Protein.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Protein.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1SaturatedFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1SaturatedFat.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1SaturatedFat {
   /** DVs are the recommended amounts of saturated fat to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of saturated fat per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of saturated fat per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1SaturatedFat {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1SaturatedFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1SaturatedFat.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of saturated fat in the product.
+ */
+export class NutritionFactsLabelV1SaturatedFat {
+  /** DVs are the recommended amounts of saturated fat to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of saturated fat per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of saturated fat per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1SaturatedFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1SaturatedFat.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1ServingSize.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1ServingSize.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,9 +8,9 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1ServingSize {
   /** The amount of a single serving. */
-  amount: number | undefined;
+  amount: number | null;
   /** The unit for the amount of a single serving. */
-  unit: string | undefined;
+  unit: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -22,8 +22,14 @@ export class NutritionFactsLabelV1ServingSize {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["amount"] && !isNaN(prediction["amount"])) {
-      this.amount = +parseFloat(prediction["amount"]).toFixed(3);
+    if (
+      prediction["amount"] !== undefined &&
+      prediction["amount"] !== null &&
+      !isNaN(prediction["amount"])
+    ) {
+      this.amount = +parseFloat(prediction["amount"]);
+    } else {
+      this.amount = null;
     }
     this.unit = prediction["unit"];
     this.pageId = prediction["page_id"];

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1ServingSize.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1ServingSize.ts
@@ -1,0 +1,67 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The size of a single serving of the product.
+ */
+export class NutritionFactsLabelV1ServingSize {
+  /** The amount of a single serving. */
+  amount: number | undefined;
+  /** The unit for the amount of a single serving. */
+  unit: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["amount"] && !isNaN(prediction["amount"])) {
+      this.amount = +parseFloat(prediction["amount"]).toFixed(3);
+    }
+    this.unit = prediction["unit"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      amount: this.amount !== undefined ? floatToString(this.amount) : "",
+      unit: this.unit ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Amount: " +
+      printable.amount +
+      ", Unit: " +
+      printable.unit
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Amount: ${printable.amount}
+  :Unit: ${printable.unit}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1ServingSize.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1ServingSize.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Sodium.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Sodium.ts
@@ -1,0 +1,87 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of sodium in the product.
+ */
+export class NutritionFactsLabelV1Sodium {
+  /** DVs are the recommended amounts of sodium to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of sodium per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of sodium per serving of the product. */
+  perServing: number | undefined;
+  /** The unit of measurement for the amount of sodium. */
+  unit: string | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.unit = prediction["unit"];
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+      unit: this.unit ?? "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing +
+      ", Unit: " +
+      printable.unit
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}
+  :Unit: ${printable.unit}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Sodium.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Sodium.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,13 +8,13 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1Sodium {
   /** DVs are the recommended amounts of sodium to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of sodium per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of sodium per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** The unit of measurement for the amount of sodium. */
-  unit: string | undefined;
+  unit: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -26,14 +26,32 @@ export class NutritionFactsLabelV1Sodium {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.unit = prediction["unit"];
     this.pageId = prediction["page_id"];

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1Sodium.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1Sodium.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalCarbohydrate.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalCarbohydrate.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1TotalCarbohydrate {
   /** DVs are the recommended amounts of total carbohydrates to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of total carbohydrates per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of total carbohydrates per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1TotalCarbohydrate {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalCarbohydrate.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalCarbohydrate.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The total amount of carbohydrates in the product.
+ */
+export class NutritionFactsLabelV1TotalCarbohydrate {
+  /** DVs are the recommended amounts of total carbohydrates to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of total carbohydrates per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of total carbohydrates per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalCarbohydrate.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalCarbohydrate.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalFat.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The total amount of fat in the product.
+ */
+export class NutritionFactsLabelV1TotalFat {
+  /** DVs are the recommended amounts of total fat to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of total fat per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of total fat per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalFat.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1TotalFat {
   /** DVs are the recommended amounts of total fat to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of total fat per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of total fat per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1TotalFat {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalFat.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalSugar.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalSugar.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The total amount of sugars in the product.
+ */
+export class NutritionFactsLabelV1TotalSugar {
+  /** DVs are the recommended amounts of total sugars to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of total sugars per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of total sugars per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalSugar.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalSugar.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1TotalSugar {
   /** DVs are the recommended amounts of total sugars to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of total sugars per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of total sugars per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1TotalSugar {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalSugar.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TotalSugar.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TransFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TransFat.ts
@@ -1,0 +1,80 @@
+import { floatToString } from "../../parsing/standard";
+import { StringDict } from "../../parsing/common";
+import { Polygon } from "../../geometry";
+
+/**
+ * The amount of trans fat in the product.
+ */
+export class NutritionFactsLabelV1TransFat {
+  /** DVs are the recommended amounts of trans fat to consume or not to exceed each day. */
+  dailyValue: number | undefined;
+  /** The amount of trans fat per 100g of the product. */
+  per100G: number | undefined;
+  /** The amount of trans fat per serving of the product. */
+  perServing: number | undefined;
+  /** Confidence score */
+  confidence: number = 0.0;
+  /** The document page on which the information was found. */
+  pageId: number;
+  /**
+   * Contains the relative vertices coordinates (points) of a polygon containing
+   * the field in the document.
+   */
+  polygon: Polygon = [];
+
+  constructor({ prediction = {} }: StringDict) {
+    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    }
+    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
+      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    }
+    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
+      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    }
+    this.pageId = prediction["page_id"];
+    this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
+    if (prediction["polygon"]) {
+      this.polygon = prediction.polygon;
+    }
+  }
+
+  /**
+   * Collection of fields as representable strings.
+   */
+  #printableValues() {
+    return {
+      dailyValue:
+        this.dailyValue !== undefined ? floatToString(this.dailyValue) : "",
+      per100G: this.per100G !== undefined ? floatToString(this.per100G) : "",
+      perServing:
+        this.perServing !== undefined ? floatToString(this.perServing) : "",
+    };
+  }
+
+  /**
+   * Default string representation.
+   */
+  toString(): string {
+    const printable = this.#printableValues();
+    return (
+      "Daily Value: " +
+      printable.dailyValue +
+      ", Per 100g: " +
+      printable.per100G +
+      ", Per Serving: " +
+      printable.perServing
+    );
+  }
+
+  /**
+   * Output in a format suitable for inclusion in a field list.
+   */
+  toFieldList(): string {
+    const printable = this.#printableValues();
+    return `
+  :Daily Value: ${printable.dailyValue}
+  :Per 100g: ${printable.per100G}
+  :Per Serving: ${printable.perServing}`.trimEnd();
+  }
+}

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TransFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TransFat.ts
@@ -1,5 +1,5 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,11 +8,11 @@ import { Polygon } from "../../geometry";
  */
 export class NutritionFactsLabelV1TransFat {
   /** DVs are the recommended amounts of trans fat to consume or not to exceed each day. */
-  dailyValue: number | undefined;
+  dailyValue: number | null;
   /** The amount of trans fat per 100g of the product. */
-  per100G: number | undefined;
+  per100G: number | null;
   /** The amount of trans fat per serving of the product. */
-  perServing: number | undefined;
+  perServing: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -24,14 +24,32 @@ export class NutritionFactsLabelV1TransFat {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["daily_value"] && !isNaN(prediction["daily_value"])) {
-      this.dailyValue = +parseFloat(prediction["daily_value"]).toFixed(3);
+    if (
+      prediction["daily_value"] !== undefined &&
+      prediction["daily_value"] !== null &&
+      !isNaN(prediction["daily_value"])
+    ) {
+      this.dailyValue = +parseFloat(prediction["daily_value"]);
+    } else {
+      this.dailyValue = null;
     }
-    if (prediction["per_100g"] && !isNaN(prediction["per_100g"])) {
-      this.per100G = +parseFloat(prediction["per_100g"]).toFixed(3);
+    if (
+      prediction["per_100g"] !== undefined &&
+      prediction["per_100g"] !== null &&
+      !isNaN(prediction["per_100g"])
+    ) {
+      this.per100G = +parseFloat(prediction["per_100g"]);
+    } else {
+      this.per100G = null;
     }
-    if (prediction["per_serving"] && !isNaN(prediction["per_serving"])) {
-      this.perServing = +parseFloat(prediction["per_serving"]).toFixed(3);
+    if (
+      prediction["per_serving"] !== undefined &&
+      prediction["per_serving"] !== null &&
+      !isNaN(prediction["per_serving"])
+    ) {
+      this.perServing = +parseFloat(prediction["per_serving"]);
+    } else {
+      this.perServing = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;

--- a/src/product/nutritionFactsLabel/nutritionFactsLabelV1TransFat.ts
+++ b/src/product/nutritionFactsLabel/nutritionFactsLabelV1TransFat.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 

--- a/src/product/receipt/receiptV5LineItem.ts
+++ b/src/product/receipt/receiptV5LineItem.ts
@@ -93,6 +93,7 @@ export class ReceiptV5LineItem {
       printable.unitPrice
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/receipt/receiptV5LineItem.ts
+++ b/src/product/receipt/receiptV5LineItem.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../parsing/standard";
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -49,8 +50,8 @@ export class ReceiptV5LineItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          this.description :
-          this.description.slice(0, 33) + "..." :
+          cleanSpaces(this.description) :
+          cleanSpaces(this.description).slice(0, 33) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       totalAmount:

--- a/src/product/receipt/receiptV5LineItem.ts
+++ b/src/product/receipt/receiptV5LineItem.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../parsing/standard";
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -8,13 +7,13 @@ import { Polygon } from "../../geometry";
  */
 export class ReceiptV5LineItem {
   /** The item description. */
-  description: string | undefined;
+  description: string | null;
   /** The item quantity. */
-  quantity: number | undefined;
+  quantity: number | null;
   /** The item total amount. */
-  totalAmount: number | undefined;
+  totalAmount: number | null;
   /** The item unit price. */
-  unitPrice: number | undefined;
+  unitPrice: number | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -27,14 +26,32 @@ export class ReceiptV5LineItem {
 
   constructor({ prediction = {} }: StringDict) {
     this.description = prediction["description"];
-    if (prediction["quantity"] && !isNaN(prediction["quantity"])) {
-      this.quantity = +parseFloat(prediction["quantity"]).toFixed(3);
+    if (
+      prediction["quantity"] !== undefined &&
+      prediction["quantity"] !== null &&
+      !isNaN(prediction["quantity"])
+    ) {
+      this.quantity = +parseFloat(prediction["quantity"]);
+    } else {
+      this.quantity = null;
     }
-    if (prediction["total_amount"] && !isNaN(prediction["total_amount"])) {
-      this.totalAmount = +parseFloat(prediction["total_amount"]).toFixed(3);
+    if (
+      prediction["total_amount"] !== undefined &&
+      prediction["total_amount"] !== null &&
+      !isNaN(prediction["total_amount"])
+    ) {
+      this.totalAmount = +parseFloat(prediction["total_amount"]);
+    } else {
+      this.totalAmount = null;
     }
-    if (prediction["unit_price"] && !isNaN(prediction["unit_price"])) {
-      this.unitPrice = +parseFloat(prediction["unit_price"]).toFixed(3);
+    if (
+      prediction["unit_price"] !== undefined &&
+      prediction["unit_price"] !== null &&
+      !isNaN(prediction["unit_price"])
+    ) {
+      this.unitPrice = +parseFloat(prediction["unit_price"]);
+    } else {
+      this.unitPrice = null;
     }
     this.pageId = prediction["page_id"];
     this.confidence = prediction["confidence"] ? prediction.confidence : 0.0;
@@ -50,8 +67,8 @@ export class ReceiptV5LineItem {
     return {
       description: this.description ?
         this.description.length <= 36 ?
-          cleanSpaces(this.description) :
-          cleanSpaces(this.description).slice(0, 33) + "..." :
+          cleanSpecialChars(this.description) :
+          cleanSpecialChars(this.description).slice(0, 33) + "..." :
         "",
       quantity: this.quantity !== undefined ? floatToString(this.quantity) : "",
       totalAmount:

--- a/src/product/resume/resumeV1Certificate.ts
+++ b/src/product/resume/resumeV1Certificate.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -42,23 +43,23 @@ export class ResumeV1Certificate {
     return {
       grade: this.grade ?
         this.grade.length <= 10 ?
-          this.grade :
-          this.grade.slice(0, 7) + "..." :
+          cleanSpaces(this.grade) :
+          cleanSpaces(this.grade).slice(0, 7) + "..." :
         "",
       name: this.name ?
         this.name.length <= 30 ?
-          this.name :
-          this.name.slice(0, 27) + "..." :
+          cleanSpaces(this.name) :
+          cleanSpaces(this.name).slice(0, 27) + "..." :
         "",
       provider: this.provider ?
         this.provider.length <= 25 ?
-          this.provider :
-          this.provider.slice(0, 22) + "..." :
+          cleanSpaces(this.provider) :
+          cleanSpaces(this.provider).slice(0, 22) + "..." :
         "",
       year: this.year ?
         this.year.length <= 4 ?
-          this.year :
-          this.year.slice(0, 1) + "..." :
+          cleanSpaces(this.year) :
+          cleanSpaces(this.year).slice(0, 1) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1Certificate.ts
+++ b/src/product/resume/resumeV1Certificate.ts
@@ -81,6 +81,7 @@ export class ResumeV1Certificate {
       printable.year
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/resume/resumeV1Certificate.ts
+++ b/src/product/resume/resumeV1Certificate.ts
@@ -1,4 +1,5 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { cleanSpecialChars } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,13 +8,13 @@ import { Polygon } from "../../geometry";
  */
 export class ResumeV1Certificate {
   /** The grade obtained for the certificate. */
-  grade: string | undefined;
+  grade: string | null;
   /** The name of certification. */
-  name: string | undefined;
+  name: string | null;
   /** The organization or institution that issued the certificate. */
-  provider: string | undefined;
+  provider: string | null;
   /** The year when a certificate was issued or received. */
-  year: string | undefined;
+  year: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -43,23 +44,23 @@ export class ResumeV1Certificate {
     return {
       grade: this.grade ?
         this.grade.length <= 10 ?
-          cleanSpaces(this.grade) :
-          cleanSpaces(this.grade).slice(0, 7) + "..." :
+          cleanSpecialChars(this.grade) :
+          cleanSpecialChars(this.grade).slice(0, 7) + "..." :
         "",
       name: this.name ?
         this.name.length <= 30 ?
-          cleanSpaces(this.name) :
-          cleanSpaces(this.name).slice(0, 27) + "..." :
+          cleanSpecialChars(this.name) :
+          cleanSpecialChars(this.name).slice(0, 27) + "..." :
         "",
       provider: this.provider ?
         this.provider.length <= 25 ?
-          cleanSpaces(this.provider) :
-          cleanSpaces(this.provider).slice(0, 22) + "..." :
+          cleanSpecialChars(this.provider) :
+          cleanSpecialChars(this.provider).slice(0, 22) + "..." :
         "",
       year: this.year ?
         this.year.length <= 4 ?
-          cleanSpaces(this.year) :
-          cleanSpaces(this.year).slice(0, 1) + "..." :
+          cleanSpecialChars(this.year) :
+          cleanSpecialChars(this.year).slice(0, 1) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1Education.ts
+++ b/src/product/resume/resumeV1Education.ts
@@ -111,6 +111,7 @@ export class ResumeV1Education {
       printable.startYear
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/resume/resumeV1Education.ts
+++ b/src/product/resume/resumeV1Education.ts
@@ -1,4 +1,5 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { cleanSpecialChars } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,19 +8,19 @@ import { Polygon } from "../../geometry";
  */
 export class ResumeV1Education {
   /** The area of study or specialization. */
-  degreeDomain: string | undefined;
+  degreeDomain: string | null;
   /** The type of degree obtained, such as Bachelor's, Master's, or Doctorate. */
-  degreeType: string | undefined;
+  degreeType: string | null;
   /** The month when the education program or course was completed. */
-  endMonth: string | undefined;
+  endMonth: string | null;
   /** The year when the education program or course was completed. */
-  endYear: string | undefined;
+  endYear: string | null;
   /** The name of the school. */
-  school: string | undefined;
+  school: string | null;
   /** The month when the education program or course began. */
-  startMonth: string | undefined;
+  startMonth: string | null;
   /** The year when the education program or course began. */
-  startYear: string | undefined;
+  startYear: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -52,38 +53,38 @@ export class ResumeV1Education {
     return {
       degreeDomain: this.degreeDomain ?
         this.degreeDomain.length <= 15 ?
-          cleanSpaces(this.degreeDomain) :
-          cleanSpaces(this.degreeDomain).slice(0, 12) + "..." :
+          cleanSpecialChars(this.degreeDomain) :
+          cleanSpecialChars(this.degreeDomain).slice(0, 12) + "..." :
         "",
       degreeType: this.degreeType ?
         this.degreeType.length <= 25 ?
-          cleanSpaces(this.degreeType) :
-          cleanSpaces(this.degreeType).slice(0, 22) + "..." :
+          cleanSpecialChars(this.degreeType) :
+          cleanSpecialChars(this.degreeType).slice(0, 22) + "..." :
         "",
       endMonth: this.endMonth ?
         this.endMonth.length <= 9 ?
-          cleanSpaces(this.endMonth) :
-          cleanSpaces(this.endMonth).slice(0, 6) + "..." :
+          cleanSpecialChars(this.endMonth) :
+          cleanSpecialChars(this.endMonth).slice(0, 6) + "..." :
         "",
       endYear: this.endYear ?
         this.endYear.length <= 8 ?
-          cleanSpaces(this.endYear) :
-          cleanSpaces(this.endYear).slice(0, 5) + "..." :
+          cleanSpecialChars(this.endYear) :
+          cleanSpecialChars(this.endYear).slice(0, 5) + "..." :
         "",
       school: this.school ?
         this.school.length <= 25 ?
-          cleanSpaces(this.school) :
-          cleanSpaces(this.school).slice(0, 22) + "..." :
+          cleanSpecialChars(this.school) :
+          cleanSpecialChars(this.school).slice(0, 22) + "..." :
         "",
       startMonth: this.startMonth ?
         this.startMonth.length <= 11 ?
-          cleanSpaces(this.startMonth) :
-          cleanSpaces(this.startMonth).slice(0, 8) + "..." :
+          cleanSpecialChars(this.startMonth) :
+          cleanSpecialChars(this.startMonth).slice(0, 8) + "..." :
         "",
       startYear: this.startYear ?
         this.startYear.length <= 10 ?
-          cleanSpaces(this.startYear) :
-          cleanSpaces(this.startYear).slice(0, 7) + "..." :
+          cleanSpecialChars(this.startYear) :
+          cleanSpecialChars(this.startYear).slice(0, 7) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1Education.ts
+++ b/src/product/resume/resumeV1Education.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -51,38 +52,38 @@ export class ResumeV1Education {
     return {
       degreeDomain: this.degreeDomain ?
         this.degreeDomain.length <= 15 ?
-          this.degreeDomain :
-          this.degreeDomain.slice(0, 12) + "..." :
+          cleanSpaces(this.degreeDomain) :
+          cleanSpaces(this.degreeDomain).slice(0, 12) + "..." :
         "",
       degreeType: this.degreeType ?
         this.degreeType.length <= 25 ?
-          this.degreeType :
-          this.degreeType.slice(0, 22) + "..." :
+          cleanSpaces(this.degreeType) :
+          cleanSpaces(this.degreeType).slice(0, 22) + "..." :
         "",
       endMonth: this.endMonth ?
         this.endMonth.length <= 9 ?
-          this.endMonth :
-          this.endMonth.slice(0, 6) + "..." :
+          cleanSpaces(this.endMonth) :
+          cleanSpaces(this.endMonth).slice(0, 6) + "..." :
         "",
       endYear: this.endYear ?
         this.endYear.length <= 8 ?
-          this.endYear :
-          this.endYear.slice(0, 5) + "..." :
+          cleanSpaces(this.endYear) :
+          cleanSpaces(this.endYear).slice(0, 5) + "..." :
         "",
       school: this.school ?
         this.school.length <= 25 ?
-          this.school :
-          this.school.slice(0, 22) + "..." :
+          cleanSpaces(this.school) :
+          cleanSpaces(this.school).slice(0, 22) + "..." :
         "",
       startMonth: this.startMonth ?
         this.startMonth.length <= 11 ?
-          this.startMonth :
-          this.startMonth.slice(0, 8) + "..." :
+          cleanSpaces(this.startMonth) :
+          cleanSpaces(this.startMonth).slice(0, 8) + "..." :
         "",
       startYear: this.startYear ?
         this.startYear.length <= 10 ?
-          this.startYear :
-          this.startYear.slice(0, 7) + "..." :
+          cleanSpaces(this.startYear) :
+          cleanSpaces(this.startYear).slice(0, 7) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1Language.ts
+++ b/src/product/resume/resumeV1Language.ts
@@ -1,4 +1,5 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { cleanSpecialChars } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,9 +8,9 @@ import { Polygon } from "../../geometry";
  */
 export class ResumeV1Language {
   /** The language's ISO 639 code. */
-  language: string | undefined;
+  language: string | null;
   /** The candidate's level for the language. */
-  level: string | undefined;
+  level: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -37,13 +38,13 @@ export class ResumeV1Language {
     return {
       language: this.language ?
         this.language.length <= 8 ?
-          cleanSpaces(this.language) :
-          cleanSpaces(this.language).slice(0, 5) + "..." :
+          cleanSpecialChars(this.language) :
+          cleanSpecialChars(this.language).slice(0, 5) + "..." :
         "",
       level: this.level ?
         this.level.length <= 20 ?
-          cleanSpaces(this.level) :
-          cleanSpaces(this.level).slice(0, 17) + "..." :
+          cleanSpecialChars(this.level) :
+          cleanSpecialChars(this.level).slice(0, 17) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1Language.ts
+++ b/src/product/resume/resumeV1Language.ts
@@ -61,6 +61,7 @@ export class ResumeV1Language {
       printable.level
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/resume/resumeV1Language.ts
+++ b/src/product/resume/resumeV1Language.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -36,13 +37,13 @@ export class ResumeV1Language {
     return {
       language: this.language ?
         this.language.length <= 8 ?
-          this.language :
-          this.language.slice(0, 5) + "..." :
+          cleanSpaces(this.language) :
+          cleanSpaces(this.language).slice(0, 5) + "..." :
         "",
       level: this.level ?
         this.level.length <= 20 ?
-          this.level :
-          this.level.slice(0, 17) + "..." :
+          cleanSpaces(this.level) :
+          cleanSpaces(this.level).slice(0, 17) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1ProfessionalExperience.ts
+++ b/src/product/resume/resumeV1ProfessionalExperience.ts
@@ -1,4 +1,5 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { cleanSpecialChars } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,21 +8,21 @@ import { Polygon } from "../../geometry";
  */
 export class ResumeV1ProfessionalExperience {
   /** The type of contract for the professional experience. */
-  contractType: string | undefined;
+  contractType: string | null;
   /** The specific department or division within the company. */
-  department: string | undefined;
+  department: string | null;
   /** The name of the company or organization. */
-  employer: string | undefined;
+  employer: string | null;
   /** The month when the professional experience ended. */
-  endMonth: string | undefined;
+  endMonth: string | null;
   /** The year when the professional experience ended. */
-  endYear: string | undefined;
+  endYear: string | null;
   /** The position or job title held by the candidate. */
-  role: string | undefined;
+  role: string | null;
   /** The month when the professional experience began. */
-  startMonth: string | undefined;
+  startMonth: string | null;
   /** The year when the professional experience began. */
-  startYear: string | undefined;
+  startYear: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -55,43 +56,43 @@ export class ResumeV1ProfessionalExperience {
     return {
       contractType: this.contractType ?
         this.contractType.length <= 15 ?
-          cleanSpaces(this.contractType) :
-          cleanSpaces(this.contractType).slice(0, 12) + "..." :
+          cleanSpecialChars(this.contractType) :
+          cleanSpecialChars(this.contractType).slice(0, 12) + "..." :
         "",
       department: this.department ?
         this.department.length <= 10 ?
-          cleanSpaces(this.department) :
-          cleanSpaces(this.department).slice(0, 7) + "..." :
+          cleanSpecialChars(this.department) :
+          cleanSpecialChars(this.department).slice(0, 7) + "..." :
         "",
       employer: this.employer ?
         this.employer.length <= 25 ?
-          cleanSpaces(this.employer) :
-          cleanSpaces(this.employer).slice(0, 22) + "..." :
+          cleanSpecialChars(this.employer) :
+          cleanSpecialChars(this.employer).slice(0, 22) + "..." :
         "",
       endMonth: this.endMonth ?
         this.endMonth.length <= 9 ?
-          cleanSpaces(this.endMonth) :
-          cleanSpaces(this.endMonth).slice(0, 6) + "..." :
+          cleanSpecialChars(this.endMonth) :
+          cleanSpecialChars(this.endMonth).slice(0, 6) + "..." :
         "",
       endYear: this.endYear ?
         this.endYear.length <= 8 ?
-          cleanSpaces(this.endYear) :
-          cleanSpaces(this.endYear).slice(0, 5) + "..." :
+          cleanSpecialChars(this.endYear) :
+          cleanSpecialChars(this.endYear).slice(0, 5) + "..." :
         "",
       role: this.role ?
         this.role.length <= 20 ?
-          cleanSpaces(this.role) :
-          cleanSpaces(this.role).slice(0, 17) + "..." :
+          cleanSpecialChars(this.role) :
+          cleanSpecialChars(this.role).slice(0, 17) + "..." :
         "",
       startMonth: this.startMonth ?
         this.startMonth.length <= 11 ?
-          cleanSpaces(this.startMonth) :
-          cleanSpaces(this.startMonth).slice(0, 8) + "..." :
+          cleanSpecialChars(this.startMonth) :
+          cleanSpecialChars(this.startMonth).slice(0, 8) + "..." :
         "",
       startYear: this.startYear ?
         this.startYear.length <= 10 ?
-          cleanSpaces(this.startYear) :
-          cleanSpaces(this.startYear).slice(0, 7) + "..." :
+          cleanSpecialChars(this.startYear) :
+          cleanSpecialChars(this.startYear).slice(0, 7) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1ProfessionalExperience.ts
+++ b/src/product/resume/resumeV1ProfessionalExperience.ts
@@ -121,6 +121,7 @@ export class ResumeV1ProfessionalExperience {
       printable.startYear
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/resume/resumeV1ProfessionalExperience.ts
+++ b/src/product/resume/resumeV1ProfessionalExperience.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -54,43 +55,43 @@ export class ResumeV1ProfessionalExperience {
     return {
       contractType: this.contractType ?
         this.contractType.length <= 15 ?
-          this.contractType :
-          this.contractType.slice(0, 12) + "..." :
+          cleanSpaces(this.contractType) :
+          cleanSpaces(this.contractType).slice(0, 12) + "..." :
         "",
       department: this.department ?
         this.department.length <= 10 ?
-          this.department :
-          this.department.slice(0, 7) + "..." :
+          cleanSpaces(this.department) :
+          cleanSpaces(this.department).slice(0, 7) + "..." :
         "",
       employer: this.employer ?
         this.employer.length <= 25 ?
-          this.employer :
-          this.employer.slice(0, 22) + "..." :
+          cleanSpaces(this.employer) :
+          cleanSpaces(this.employer).slice(0, 22) + "..." :
         "",
       endMonth: this.endMonth ?
         this.endMonth.length <= 9 ?
-          this.endMonth :
-          this.endMonth.slice(0, 6) + "..." :
+          cleanSpaces(this.endMonth) :
+          cleanSpaces(this.endMonth).slice(0, 6) + "..." :
         "",
       endYear: this.endYear ?
         this.endYear.length <= 8 ?
-          this.endYear :
-          this.endYear.slice(0, 5) + "..." :
+          cleanSpaces(this.endYear) :
+          cleanSpaces(this.endYear).slice(0, 5) + "..." :
         "",
       role: this.role ?
         this.role.length <= 20 ?
-          this.role :
-          this.role.slice(0, 17) + "..." :
+          cleanSpaces(this.role) :
+          cleanSpaces(this.role).slice(0, 17) + "..." :
         "",
       startMonth: this.startMonth ?
         this.startMonth.length <= 11 ?
-          this.startMonth :
-          this.startMonth.slice(0, 8) + "..." :
+          cleanSpaces(this.startMonth) :
+          cleanSpaces(this.startMonth).slice(0, 8) + "..." :
         "",
       startYear: this.startYear ?
         this.startYear.length <= 10 ?
-          this.startYear :
-          this.startYear.slice(0, 7) + "..." :
+          cleanSpaces(this.startYear) :
+          cleanSpaces(this.startYear).slice(0, 7) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1SocialNetworksUrl.ts
+++ b/src/product/resume/resumeV1SocialNetworksUrl.ts
@@ -1,4 +1,5 @@
-import { cleanSpaces } from "../../parsing/common/summaryHelper";
+
+import { cleanSpecialChars } from "../../parsing/common";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -7,9 +8,9 @@ import { Polygon } from "../../geometry";
  */
 export class ResumeV1SocialNetworksUrl {
   /** The name of the social network. */
-  name: string | undefined;
+  name: string | null;
   /** The URL of the social network. */
-  url: string | undefined;
+  url: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -37,13 +38,13 @@ export class ResumeV1SocialNetworksUrl {
     return {
       name: this.name ?
         this.name.length <= 20 ?
-          cleanSpaces(this.name) :
-          cleanSpaces(this.name).slice(0, 17) + "..." :
+          cleanSpecialChars(this.name) :
+          cleanSpecialChars(this.name).slice(0, 17) + "..." :
         "",
       url: this.url ?
         this.url.length <= 50 ?
-          cleanSpaces(this.url) :
-          cleanSpaces(this.url).slice(0, 47) + "..." :
+          cleanSpecialChars(this.url) :
+          cleanSpecialChars(this.url).slice(0, 47) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1SocialNetworksUrl.ts
+++ b/src/product/resume/resumeV1SocialNetworksUrl.ts
@@ -1,3 +1,4 @@
+import { cleanSpaces } from "../../parsing/common/summaryHelper";
 import { StringDict } from "../../parsing/common";
 import { Polygon } from "../../geometry";
 
@@ -36,13 +37,13 @@ export class ResumeV1SocialNetworksUrl {
     return {
       name: this.name ?
         this.name.length <= 20 ?
-          this.name :
-          this.name.slice(0, 17) + "..." :
+          cleanSpaces(this.name) :
+          cleanSpaces(this.name).slice(0, 17) + "..." :
         "",
       url: this.url ?
         this.url.length <= 50 ?
-          this.url :
-          this.url.slice(0, 47) + "..." :
+          cleanSpaces(this.url) :
+          cleanSpaces(this.url).slice(0, 47) + "..." :
         "",
     };
   }

--- a/src/product/resume/resumeV1SocialNetworksUrl.ts
+++ b/src/product/resume/resumeV1SocialNetworksUrl.ts
@@ -61,6 +61,7 @@ export class ResumeV1SocialNetworksUrl {
       printable.url
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/us/healthcareCard/healthcareCardV1Copay.ts
+++ b/src/product/us/healthcareCard/healthcareCardV1Copay.ts
@@ -1,5 +1,4 @@
-import { floatToString } from "../../../parsing/standard";
-import { cleanSpaces } from "../../../parsing/common/summaryHelper";
+import { cleanSpecialChars, floatToString } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -8,9 +7,9 @@ import { Polygon } from "../../../geometry";
  */
 export class HealthcareCardV1Copay {
   /** The price of service. */
-  serviceFees: number | undefined;
+  serviceFees: number | null;
   /** The name of service of the copay. */
-  serviceName: string | undefined;
+  serviceName: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -22,8 +21,14 @@ export class HealthcareCardV1Copay {
   polygon: Polygon = [];
 
   constructor({ prediction = {} }: StringDict) {
-    if (prediction["service_fees"] && !isNaN(prediction["service_fees"])) {
-      this.serviceFees = +parseFloat(prediction["service_fees"]).toFixed(3);
+    if (
+      prediction["service_fees"] !== undefined &&
+      prediction["service_fees"] !== null &&
+      !isNaN(prediction["service_fees"])
+    ) {
+      this.serviceFees = +parseFloat(prediction["service_fees"]);
+    } else {
+      this.serviceFees = null;
     }
     this.serviceName = prediction["service_name"];
     this.pageId = prediction["page_id"];
@@ -42,8 +47,8 @@ export class HealthcareCardV1Copay {
         this.serviceFees !== undefined ? floatToString(this.serviceFees) : "",
       serviceName: this.serviceName ?
         this.serviceName.length <= 12 ?
-          cleanSpaces(this.serviceName) :
-          cleanSpaces(this.serviceName).slice(0, 9) + "..." :
+          cleanSpecialChars(this.serviceName) :
+          cleanSpecialChars(this.serviceName).slice(0, 9) + "..." :
         "",
     };
   }

--- a/src/product/us/healthcareCard/healthcareCardV1Copay.ts
+++ b/src/product/us/healthcareCard/healthcareCardV1Copay.ts
@@ -1,4 +1,5 @@
 import { floatToString } from "../../../parsing/standard";
+import { cleanSpaces } from "../../../parsing/common/summaryHelper";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -41,8 +42,8 @@ export class HealthcareCardV1Copay {
         this.serviceFees !== undefined ? floatToString(this.serviceFees) : "",
       serviceName: this.serviceName ?
         this.serviceName.length <= 12 ?
-          this.serviceName :
-          this.serviceName.slice(0, 9) + "..." :
+          cleanSpaces(this.serviceName) :
+          cleanSpaces(this.serviceName).slice(0, 9) + "..." :
         "",
     };
   }

--- a/src/product/us/healthcareCard/healthcareCardV1Copay.ts
+++ b/src/product/us/healthcareCard/healthcareCardV1Copay.ts
@@ -65,6 +65,7 @@ export class HealthcareCardV1Copay {
       printable.serviceName
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/us/usMail/index.ts
+++ b/src/product/us/usMail/index.ts
@@ -1,0 +1,1 @@
+export { UsMailV2 } from "./usMailV2";

--- a/src/product/us/usMail/usMailV2RecipientAddress.ts
+++ b/src/product/us/usMail/usMailV2RecipientAddress.ts
@@ -111,6 +111,7 @@ export class UsMailV2RecipientAddress {
       printable.street
     );
   }
+
   /**
    * Output in a format suitable for inclusion in an rST table.
    */

--- a/src/product/us/usMail/usMailV2RecipientAddress.ts
+++ b/src/product/us/usMail/usMailV2RecipientAddress.ts
@@ -1,3 +1,5 @@
+
+import { cleanSpecialChars } from "../../../parsing/common";
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -6,19 +8,19 @@ import { Polygon } from "../../../geometry";
  */
 export class UsMailV2RecipientAddress {
   /** The city of the recipient's address. */
-  city: string | undefined;
+  city: string | null;
   /** The complete address of the recipient. */
-  complete: string | undefined;
+  complete: string | null;
   /** Indicates if the recipient's address is a change of address. */
-  isAddressChange: boolean | undefined;
+  isAddressChange: boolean | null;
   /** The postal code of the recipient's address. */
-  postalCode: string | undefined;
+  postalCode: string | null;
   /** The private mailbox number of the recipient's address. */
-  privateMailboxNumber: string | undefined;
+  privateMailboxNumber: string | null;
   /** Second part of the ISO 3166-2 code, consisting of two letters indicating the US State. */
-  state: string | undefined;
+  state: string | null;
   /** The street of the recipient's address. */
-  street: string | undefined;
+  street: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -51,37 +53,38 @@ export class UsMailV2RecipientAddress {
     return {
       city: this.city ?
         this.city.length <= 15 ?
-          this.city :
-          this.city.slice(0, 12) + "..." :
+          cleanSpecialChars(this.city) :
+          cleanSpecialChars(this.city).slice(0, 12) + "..." :
         "",
       complete: this.complete ?
         this.complete.length <= 35 ?
-          this.complete :
-          this.complete.slice(0, 32) + "..." :
+          cleanSpecialChars(this.complete) :
+          cleanSpecialChars(this.complete).slice(0, 32) + "..." :
         "",
       isAddressChange: this.isAddressChange === true ?
-        "True" : this.isAddressChange === false ?
+        "True" :
+        this.isAddressChange === false ?
           "False" :
           "",
       postalCode: this.postalCode ?
         this.postalCode.length <= 11 ?
-          this.postalCode :
-          this.postalCode.slice(0, 8) + "..." :
+          cleanSpecialChars(this.postalCode) :
+          cleanSpecialChars(this.postalCode).slice(0, 8) + "..." :
         "",
       privateMailboxNumber: this.privateMailboxNumber ?
         this.privateMailboxNumber.length <= 22 ?
-          this.privateMailboxNumber :
-          this.privateMailboxNumber.slice(0, 19) + "..." :
+          cleanSpecialChars(this.privateMailboxNumber) :
+          cleanSpecialChars(this.privateMailboxNumber).slice(0, 19) + "..." :
         "",
       state: this.state ?
         this.state.length <= 5 ?
-          this.state :
-          this.state.slice(0, 2) + "..." :
+          cleanSpecialChars(this.state) :
+          cleanSpecialChars(this.state).slice(0, 2) + "..." :
         "",
       street: this.street ?
         this.street.length <= 25 ?
-          this.street :
-          this.street.slice(0, 22) + "..." :
+          cleanSpecialChars(this.street) :
+          cleanSpecialChars(this.street).slice(0, 22) + "..." :
         "",
     };
   }

--- a/src/product/us/usMail/usMailV2SenderAddress.ts
+++ b/src/product/us/usMail/usMailV2SenderAddress.ts
@@ -1,3 +1,4 @@
+
 import { StringDict } from "../../../parsing/common";
 import { Polygon } from "../../../geometry";
 
@@ -6,15 +7,15 @@ import { Polygon } from "../../../geometry";
  */
 export class UsMailV2SenderAddress {
   /** The city of the sender's address. */
-  city: string | undefined;
+  city: string | null;
   /** The complete address of the sender. */
-  complete: string | undefined;
+  complete: string | null;
   /** The postal code of the sender's address. */
-  postalCode: string | undefined;
+  postalCode: string | null;
   /** Second part of the ISO 3166-2 code, consisting of two letters indicating the US State. */
-  state: string | undefined;
+  state: string | null;
   /** The street of the sender's address. */
-  street: string | undefined;
+  street: string | null;
   /** Confidence score */
   confidence: number = 0.0;
   /** The document page on which the information was found. */
@@ -43,31 +44,11 @@ export class UsMailV2SenderAddress {
    */
   #printableValues() {
     return {
-      city: this.city ?
-        this.city.length <= 15 ?
-          this.city :
-          this.city.slice(0, 12) + "..." :
-        "",
-      complete: this.complete ?
-        this.complete.length <= 35 ?
-          this.complete :
-          this.complete.slice(0, 32) + "..." :
-        "",
-      postalCode: this.postalCode ?
-        this.postalCode.length <= 11 ?
-          this.postalCode :
-          this.postalCode.slice(0, 8) + "..." :
-        "",
-      state: this.state ?
-        this.state.length <= 5 ?
-          this.state :
-          this.state.slice(0, 2) + "..." :
-        "",
-      street: this.street ?
-        this.street.length <= 25 ?
-          this.street :
-          this.street.slice(0, 22) + "..." :
-        "",
+      city: this.city ?? "",
+      complete: this.complete ?? "",
+      postalCode: this.postalCode ?? "",
+      state: this.state ?? "",
+      street: this.street ?? "",
     };
   }
 

--- a/tests/product/billOfLading/billOfLadingV1.spec.ts
+++ b/tests/product/billOfLading/billOfLadingV1.spec.ts
@@ -1,0 +1,51 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import { expect } from "chai";
+import * as mindee from "../../../src";
+
+
+const dataPath = {
+  complete: "tests/data/products/bill_of_lading/response_v1/complete.json",
+  empty: "tests/data/products/bill_of_lading/response_v1/empty.json",
+  docString: "tests/data/products/bill_of_lading/response_v1/summary_full.rst",
+  page0String: "tests/data/products/bill_of_lading/response_v1/summary_page0.rst",
+};
+
+describe("BillOfLadingV1 Object initialization", async () => {
+  it("should load an empty document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.empty));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.BillOfLadingV1, response.document);
+    const docPrediction = doc.inference.prediction;
+    expect(docPrediction.billOfLadingNumber.value).to.be.undefined;
+    expect(docPrediction.shipper.address).to.be.null;
+    expect(docPrediction.shipper.email).to.be.null;
+    expect(docPrediction.shipper.name).to.be.null;
+    expect(docPrediction.shipper.phone).to.be.null;
+    expect(docPrediction.consignee.address).to.be.null;
+    expect(docPrediction.consignee.email).to.be.null;
+    expect(docPrediction.consignee.name).to.be.null;
+    expect(docPrediction.consignee.phone).to.be.null;
+    expect(docPrediction.notifyParty.address).to.be.null;
+    expect(docPrediction.notifyParty.email).to.be.null;
+    expect(docPrediction.notifyParty.name).to.be.null;
+    expect(docPrediction.notifyParty.phone).to.be.null;
+    expect(docPrediction.carrier.name).to.be.null;
+    expect(docPrediction.carrier.professionalNumber).to.be.null;
+    expect(docPrediction.carrier.scac).to.be.null;
+    expect(docPrediction.carrierItems.length).to.be.equals(0);
+    expect(docPrediction.portOfLoading.value).to.be.undefined;
+    expect(docPrediction.portOfDischarge.value).to.be.undefined;
+    expect(docPrediction.placeOfDelivery.value).to.be.undefined;
+    expect(docPrediction.dateOfIssue.value).to.be.undefined;
+    expect(docPrediction.departureDate.value).to.be.undefined;
+  });
+
+  it("should load a complete document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.complete));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.BillOfLadingV1, response.document);
+    const docString = await fs.readFile(path.join(dataPath.docString));
+    expect(doc.toString()).to.be.equals(docString.toString());
+  });
+});

--- a/tests/product/fr/energyBill/energyBillV1.spec.ts
+++ b/tests/product/fr/energyBill/energyBillV1.spec.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import { expect } from "chai";
+import * as mindee from "../../../../src";
+
+
+const dataPath = {
+  complete: "tests/data/products/energy_bill_fra/response_v1/complete.json",
+  empty: "tests/data/products/energy_bill_fra/response_v1/empty.json",
+  docString: "tests/data/products/energy_bill_fra/response_v1/summary_full.rst",
+  page0String: "tests/data/products/energy_bill_fra/response_v1/summary_page0.rst",
+};
+
+describe("EnergyBillV1 Object initialization", async () => {
+  it("should load an empty document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.empty));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.fr.EnergyBillV1, response.document);
+    const docPrediction = doc.inference.prediction;
+    expect(docPrediction.invoiceNumber.value).to.be.undefined;
+    expect(docPrediction.contractId.value).to.be.undefined;
+    expect(docPrediction.deliveryPoint.value).to.be.undefined;
+    expect(docPrediction.invoiceDate.value).to.be.undefined;
+    expect(docPrediction.dueDate.value).to.be.undefined;
+    expect(docPrediction.totalBeforeTaxes.value).to.be.undefined;
+    expect(docPrediction.totalTaxes.value).to.be.undefined;
+    expect(docPrediction.totalAmount.value).to.be.undefined;
+    expect(docPrediction.energySupplier.address).to.be.null;
+    expect(docPrediction.energySupplier.name).to.be.null;
+    expect(docPrediction.energyConsumer.address).to.be.null;
+    expect(docPrediction.energyConsumer.name).to.be.null;
+    expect(docPrediction.subscription.length).to.be.equals(0);
+    expect(docPrediction.energyUsage.length).to.be.equals(0);
+    expect(docPrediction.taxesAndContributions.length).to.be.equals(0);
+    expect(docPrediction.meterDetails.meterNumber).to.be.null;
+    expect(docPrediction.meterDetails.meterType).to.be.null;
+    expect(docPrediction.meterDetails.unit).to.be.null;
+  });
+
+  it("should load a complete document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.complete));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.fr.EnergyBillV1, response.document);
+    const docString = await fs.readFile(path.join(dataPath.docString));
+    expect(doc.toString()).to.be.equals(docString.toString());
+  });
+});

--- a/tests/product/fr/payslip/payslipV2.spec.ts
+++ b/tests/product/fr/payslip/payslipV2.spec.ts
@@ -1,0 +1,71 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import { expect } from "chai";
+import * as mindee from "../../../../src";
+
+
+const dataPath = {
+  complete: "tests/data/products/payslip_fra/response_v2/complete.json",
+  empty: "tests/data/products/payslip_fra/response_v2/empty.json",
+  docString: "tests/data/products/payslip_fra/response_v2/summary_full.rst",
+  page0String: "tests/data/products/payslip_fra/response_v2/summary_page0.rst",
+};
+
+describe("PayslipV2 Object initialization", async () => {
+  it("should load an empty document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.empty));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.fr.PayslipV2, response.document);
+    const docPrediction = doc.inference.prediction;
+    expect(docPrediction.employee.address).to.be.null;
+    expect(docPrediction.employee.dateOfBirth).to.be.null;
+    expect(docPrediction.employee.firstName).to.be.null;
+    expect(docPrediction.employee.lastName).to.be.null;
+    expect(docPrediction.employee.phoneNumber).to.be.null;
+    expect(docPrediction.employee.registrationNumber).to.be.null;
+    expect(docPrediction.employee.socialSecurityNumber).to.be.null;
+    expect(docPrediction.employer.address).to.be.null;
+    expect(docPrediction.employer.companyId).to.be.null;
+    expect(docPrediction.employer.companySite).to.be.null;
+    expect(docPrediction.employer.nafCode).to.be.null;
+    expect(docPrediction.employer.name).to.be.null;
+    expect(docPrediction.employer.phoneNumber).to.be.null;
+    expect(docPrediction.employer.urssafNumber).to.be.null;
+    expect(docPrediction.bankAccountDetails.bankName).to.be.null;
+    expect(docPrediction.bankAccountDetails.iban).to.be.null;
+    expect(docPrediction.bankAccountDetails.swift).to.be.null;
+    expect(docPrediction.employment.category).to.be.null;
+    expect(docPrediction.employment.coefficient).to.be.null;
+    expect(docPrediction.employment.collectiveAgreement).to.be.null;
+    expect(docPrediction.employment.jobTitle).to.be.null;
+    expect(docPrediction.employment.positionLevel).to.be.null;
+    expect(docPrediction.employment.startDate).to.be.null;
+    expect(docPrediction.salaryDetails.length).to.be.equals(0);
+    expect(docPrediction.payDetail.grossSalary).to.be.null;
+    expect(docPrediction.payDetail.grossSalaryYtd).to.be.null;
+    expect(docPrediction.payDetail.incomeTaxRate).to.be.null;
+    expect(docPrediction.payDetail.incomeTaxWithheld).to.be.null;
+    expect(docPrediction.payDetail.netPaid).to.be.null;
+    expect(docPrediction.payDetail.netPaidBeforeTax).to.be.null;
+    expect(docPrediction.payDetail.netTaxable).to.be.null;
+    expect(docPrediction.payDetail.netTaxableYtd).to.be.null;
+    expect(docPrediction.payDetail.totalCostEmployer).to.be.null;
+    expect(docPrediction.payDetail.totalTaxesAndDeductions).to.be.null;
+    expect(docPrediction.pto.accruedThisPeriod).to.be.null;
+    expect(docPrediction.pto.balanceEndOfPeriod).to.be.null;
+    expect(docPrediction.pto.usedThisPeriod).to.be.null;
+    expect(docPrediction.payPeriod.endDate).to.be.null;
+    expect(docPrediction.payPeriod.month).to.be.null;
+    expect(docPrediction.payPeriod.paymentDate).to.be.null;
+    expect(docPrediction.payPeriod.startDate).to.be.null;
+    expect(docPrediction.payPeriod.year).to.be.null;
+  });
+
+  it("should load a complete document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.complete));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.fr.PayslipV2, response.document);
+    const docString = await fs.readFile(path.join(dataPath.docString));
+    expect(doc.toString()).to.be.equals(docString.toString());
+  });
+});

--- a/tests/product/nutritionFactsLabel/nutritionFactsLabelV1.spec.ts
+++ b/tests/product/nutritionFactsLabel/nutritionFactsLabelV1.spec.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import { expect } from "chai";
+import * as mindee from "../../../src";
+
+
+const dataPath = {
+  complete: "tests/data/products/nutrition_facts/response_v1/complete.json",
+  empty: "tests/data/products/nutrition_facts/response_v1/empty.json",
+  docString: "tests/data/products/nutrition_facts/response_v1/summary_full.rst",
+  page0String: "tests/data/products/nutrition_facts/response_v1/summary_page0.rst",
+};
+
+describe("NutritionFactsLabelV1 Object initialization", async () => {
+  it("should load an empty document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.empty));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.NutritionFactsLabelV1, response.document);
+    const docPrediction = doc.inference.prediction;
+    expect(docPrediction.servingPerBox.value).to.be.undefined;
+    expect(docPrediction.servingSize.amount).to.be.null;
+    expect(docPrediction.servingSize.unit).to.be.null;
+    expect(docPrediction.calories.dailyValue).to.be.null;
+    expect(docPrediction.calories.per100G).to.be.null;
+    expect(docPrediction.calories.perServing).to.be.null;
+    expect(docPrediction.totalFat.dailyValue).to.be.null;
+    expect(docPrediction.totalFat.per100G).to.be.null;
+    expect(docPrediction.totalFat.perServing).to.be.null;
+    expect(docPrediction.saturatedFat.dailyValue).to.be.null;
+    expect(docPrediction.saturatedFat.per100G).to.be.null;
+    expect(docPrediction.saturatedFat.perServing).to.be.null;
+    expect(docPrediction.transFat.dailyValue).to.be.null;
+    expect(docPrediction.transFat.per100G).to.be.null;
+    expect(docPrediction.transFat.perServing).to.be.null;
+    expect(docPrediction.cholesterol.dailyValue).to.be.null;
+    expect(docPrediction.cholesterol.per100G).to.be.null;
+    expect(docPrediction.cholesterol.perServing).to.be.null;
+    expect(docPrediction.totalCarbohydrate.dailyValue).to.be.null;
+    expect(docPrediction.totalCarbohydrate.per100G).to.be.null;
+    expect(docPrediction.totalCarbohydrate.perServing).to.be.null;
+    expect(docPrediction.dietaryFiber.dailyValue).to.be.null;
+    expect(docPrediction.dietaryFiber.per100G).to.be.null;
+    expect(docPrediction.dietaryFiber.perServing).to.be.null;
+    expect(docPrediction.totalSugars.dailyValue).to.be.null;
+    expect(docPrediction.totalSugars.per100G).to.be.null;
+    expect(docPrediction.totalSugars.perServing).to.be.null;
+    expect(docPrediction.addedSugars.dailyValue).to.be.null;
+    expect(docPrediction.addedSugars.per100G).to.be.null;
+    expect(docPrediction.addedSugars.perServing).to.be.null;
+    expect(docPrediction.protein.dailyValue).to.be.null;
+    expect(docPrediction.protein.per100G).to.be.null;
+    expect(docPrediction.protein.perServing).to.be.null;
+    expect(docPrediction.sodium.dailyValue).to.be.null;
+    expect(docPrediction.sodium.per100G).to.be.null;
+    expect(docPrediction.sodium.perServing).to.be.null;
+    expect(docPrediction.sodium.unit).to.be.null;
+    expect(docPrediction.nutrients.length).to.be.equals(0);
+  });
+
+  it("should load a complete document prediction", async () => {
+    const jsonData = await fs.readFile(path.resolve(dataPath.complete));
+    const response = JSON.parse(jsonData.toString());
+    const doc = new mindee.Document(mindee.product.NutritionFactsLabelV1, response.document);
+    const docString = await fs.readFile(path.join(dataPath.docString));
+    expect(doc.toString()).to.be.equals(docString.toString());
+  });
+});

--- a/tests/product/us/usMail/usMailV2.spec.ts
+++ b/tests/product/us/usMail/usMailV2.spec.ts
@@ -18,11 +18,11 @@ describe("UsMailV2 Object initialization", async () => {
     const doc = new mindee.Document(mindee.product.us.UsMailV2, response.document);
     const docPrediction = doc.inference.prediction;
     expect(docPrediction.senderName.value).to.be.undefined;
-    expect(docPrediction.senderAddress.city).to.be.undefined;
-    expect(docPrediction.senderAddress.complete).to.be.undefined;
-    expect(docPrediction.senderAddress.postalCode).to.be.undefined;
-    expect(docPrediction.senderAddress.state).to.be.undefined;
-    expect(docPrediction.senderAddress.street).to.be.undefined;
+    expect(docPrediction.senderAddress.city).to.be.null;
+    expect(docPrediction.senderAddress.complete).to.be.null;
+    expect(docPrediction.senderAddress.postalCode).to.be.null;
+    expect(docPrediction.senderAddress.state).to.be.null;
+    expect(docPrediction.senderAddress.street).to.be.null;
     expect(docPrediction.recipientNames.length).to.be.equals(0);
     expect(docPrediction.recipientAddresses.length).to.be.equals(0);
   });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add support for:
* :sparkles: US Mail V2
* :sparkles: Bill of Lading V1
* :sparkles: FR Energy Bill V1
* :sparkles: FR Payslips V1
* :sparkles: Nutrition Facts Label V1

Also:
* :bug: Fix number display issues
* :bug: Fix boolean display issues
* :recycle: refactor summary helper
* :recycle: Update testing library
* :bug: fix null coercion in product classes

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires a change to the official Guide documentation.
