### PR TITLE
:bug: retry once on connection error

### DIFF
--- a/src/http/apiCore.ts
+++ b/src/http/apiCore.ts
@@ -48,16 +48,26 @@ export async function sendRequestAndReadResponse(
       requestUrl.searchParams.set(key, value);
     }
   }
-  const response = await request(
-    requestUrl,
-    {
-      method: options.method,
-      headers: options.headers,
-      headersTimeout: options.timeoutSecs * 1000,
-      body: options.body,
-      dispatcher: dispatcher,
-    }
-  );
+  const requestParams = {
+    method: options.method,
+    headers: options.headers,
+    headersTimeout: options.timeoutSecs * 1000,
+    body: options.body,
+    dispatcher: dispatcher,
+  };
+  let response: Dispatcher.ResponseData;
+  try {
+    response = await request(
+      requestUrl, requestParams
+    );
+  } catch (err: any) {
+    // shenanigans in networking or freezing/thawing of the process in serverless environments
+    if (err.code === "UND_ERR_SOCKET" || err.code === "UND_ERR_CONNECT_TIMEOUT" || err.code === "ECONNRESET") {
+      logger.warn(`Socket error (${err.code}), retrying with a fresh connection...`);
+      response = await request(requestUrl, requestParams);
+    } else throw err;
+  }
+
   logger.debug("Parsing the response ...");
 
   let responseBody: string = await response.body.text();

--- a/tests/http/apiCore.spec.ts
+++ b/tests/http/apiCore.spec.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MockAgent } from "undici";
+import { sendRequestAndReadResponse, RequestOptions } from "@/http/apiCore.js";
+
+const HOST = "api-core-host";
+const PATH = "/endiiiiives/will/always/love/you";
+const SUCCESS_BODY = JSON.stringify({ result: "ok" });
+
+const BASE_OPTIONS: RequestOptions = {
+  hostname: HOST,
+  path: PATH,
+  method: "GET",
+  headers: {},
+  timeoutSecs: 10,
+};
+
+function socketError(code: string): Error {
+  return Object.assign(new Error("socket closed"), { code });
+}
+
+type Interceptor =
+  | { error: Error }
+  | { statusCode: number; body: string };
+
+function makeAgent(...interceptors: Interceptor[]): MockAgent {
+  const mockAgent = new MockAgent();
+  const pool = mockAgent.get(`https://${HOST}`);
+  for (const interceptor of interceptors) {
+    const mock = pool.intercept({ path: PATH, method: "GET" });
+    if ("error" in interceptor) {
+      mock.replyWithError(interceptor.error);
+    } else {
+      mock.reply(interceptor.statusCode, interceptor.body);
+    }
+  }
+  return mockAgent;
+}
+
+async function sendRequest(agent: MockAgent): Promise<any> {
+  return sendRequestAndReadResponse(agent, BASE_OPTIONS);
+}
+
+describe("sendRequestAndReadResponse – retry logic", () => {
+
+  it("succeeds on first attempt when no error", async () => {
+    const agent = makeAgent({ statusCode: 200, body: SUCCESS_BODY });
+    const result = await sendRequest(agent);
+    assert.deepStrictEqual(result.data, { result: "ok" });
+  });
+
+  it("retries once on UND_ERR_SOCKET and returns the retry response", async () => {
+    const agent = makeAgent(
+      { error: socketError("UND_ERR_SOCKET") },
+      { statusCode: 200, body: SUCCESS_BODY }
+    );
+    const result = await sendRequest(agent);
+    assert.deepStrictEqual(result.data, { result: "ok" });
+  });
+
+  it("retries once on ECONNRESET and returns the retry response", async () => {
+    const agent = makeAgent(
+      { error: socketError("ECONNRESET") },
+      { statusCode: 200, body: SUCCESS_BODY }
+    );
+    const result = await sendRequest(agent);
+    assert.deepStrictEqual(result.data, { result: "ok" });
+  });
+
+  it("retries once on UND_ERR_CONNECT_TIMEOUT and returns the retry response", async () => {
+    const agent = makeAgent(
+      { error: socketError("UND_ERR_CONNECT_TIMEOUT") },
+      { statusCode: 200, body: SUCCESS_BODY }
+    );
+    const result = await sendRequest(agent);
+    assert.deepStrictEqual(result.data, { result: "ok" });
+  });
+
+  it("propagates the error when the retry also fails", async () => {
+    const agent = makeAgent(
+      { error: socketError("UND_ERR_SOCKET") },
+      { error: socketError("UND_ERR_SOCKET") }
+    );
+    await assert.rejects(
+      sendRequest(agent),
+      (err: any) => {
+        assert.strictEqual(err.code, "UND_ERR_SOCKET");
+        return true;
+      }
+    );
+  });
+
+  it("does not retry on unrelated errors and propagates immediately", async () => {
+    const agent = makeAgent(
+      { error: Object.assign(new Error("connection refused"), { code: "ECONNREFUSED" }) }
+    );
+    await assert.rejects(
+      sendRequest(agent),
+      (err: any) => {
+        assert.strictEqual(err.code, "ECONNREFUSED");
+        return true;
+      }
+    );
+  });
+
+});

--- a/tests/v1/workflows/workflow.spec.ts
+++ b/tests/v1/workflows/workflow.spec.ts
@@ -2,23 +2,22 @@ import path from "path";
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { promises as fs } from "fs";
-import { MockAgent, setGlobalDispatcher } from "undici";
+import { MockAgent } from "undici";
 import { RESOURCE_PATH, V1_RESOURCE_PATH } from "../../index.js";
 import { Client } from "@/v1/index.js";
 import { PathInput } from "@/index.js";
 
-const mockAgent = new MockAgent();
-setGlobalDispatcher(mockAgent);
-const mockPool = mockAgent.get("https://v1-workflow-host");
-
-async function setInterceptor(httpCode: number, jsonFilePath: string) {
+async function setInterceptor(httpCode: number, jsonFilePath: string): Promise<MockAgent> {
+  const mockAgent = new MockAgent();
+  const mockPool = mockAgent.get("https://v1-workflow-host");
   const mockResponse = JSON.parse(await fs.readFile(jsonFilePath, "utf-8"));
   mockPool
     .intercept({ path: /v1\/workflows\/.*/, method: "POST" })
     .reply(httpCode, mockResponse);
+  return mockAgent;
 }
 
-async function executeWorkflow(doc: PathInput, workflowId: string) {
+async function executeWorkflow(mockAgent: MockAgent, doc: PathInput, workflowId: string) {
   const client = new Client({ apiKey: "my-api-key", debug: true, dispatcher: mockAgent });
   return await client.executeWorkflow(doc, workflowId);
 }
@@ -38,9 +37,9 @@ describe("MindeeV1 - Workflow executions", () => {
 
   it("should deserialize response correctly when sending a document to an execution", async () => {
     const jsonFilePath = path.join(V1_RESOURCE_PATH, "workflows", "success.json");
-    await setInterceptor(202, jsonFilePath);
+    const mockAgent = await setInterceptor(202, jsonFilePath);
     const mockedExecution = await executeWorkflow(
-      doc, "07ebf237-ff27-4eee-b6a2-425df4a5cca6"
+      mockAgent, doc, "07ebf237-ff27-4eee-b6a2-425df4a5cca6"
     );
     assert.notStrictEqual(mockedExecution, null);
     assert.notStrictEqual(mockedExecution.apiRequest, null);
@@ -62,9 +61,9 @@ describe("MindeeV1 - Workflow executions", () => {
   it("should deserialize response correctly when sending a document to an execution with priority and alias",
     async () => {
       const jsonFilePath = path.join(V1_RESOURCE_PATH, "workflows", "success_low_priority.json");
-      await setInterceptor(200, jsonFilePath);
+      const mockAgent = await setInterceptor(200, jsonFilePath);
       const mockedExecution = await executeWorkflow(
-        doc, "07ebf237-ff27-4eee-b6a2-425df4a5cca6"
+        mockAgent, doc, "07ebf237-ff27-4eee-b6a2-425df4a5cca6"
       );
       assert.notStrictEqual(mockedExecution, null);
       assert.notStrictEqual(mockedExecution.apiRequest, null);

--- a/tests/v2/client/client.spec.ts
+++ b/tests/v2/client/client.spec.ts
@@ -1,16 +1,12 @@
 import path from "path";
 import assert from "node:assert/strict";
 import { after, before, beforeEach, describe, it } from "node:test";
-import { MockAgent, setGlobalDispatcher } from "undici";
+import { MockAgent, Interceptable } from "undici";
 import fs from "node:fs/promises";
 
 import { Client, PathInput, product } from "@/index.js";
 import { MindeeHttpErrorV2 } from "@/v2/http/index.js";
 import { RESOURCE_PATH, V2_RESOURCE_PATH } from "../../index.js";
-
-const mockAgent = new MockAgent();
-setGlobalDispatcher(mockAgent);
-const mockPool = mockAgent.get("https://v2-client-host");
 
 /**
  * Injects a minimal set of environment variables so that the SDK behaves
@@ -21,14 +17,16 @@ function dummyEnvvars(): void {
   process.env.MINDEE_V2_API_HOST = "v2-client-host";
 }
 
-async function setInterceptor(statusCode: number, filePath: string): Promise<void> {
+async function setInterceptor(mockPool: Interceptable, statusCode: number, filePath: string): Promise<void> {
   const fileObj = await fs.readFile(filePath, { encoding: "utf-8" });
   mockPool
     .intercept({ path: /.*/, method: "GET" })
     .reply(statusCode, fileObj);
 }
 
-async function setAllInterceptors(): Promise<void> {
+async function setAllInterceptors(): Promise<MockAgent> {
+  const mockAgent = new MockAgent();
+  const mockPool = mockAgent.get("https://v2-client-host");
   mockPool
     .intercept({ path: /.*/, method: "POST" })
     .reply(
@@ -36,9 +34,11 @@ async function setAllInterceptors(): Promise<void> {
       { status: 400, detail: "forced failure from test", title: "Bad Request", code: "400-001" }
     );
   await setInterceptor(
+    mockPool,
     200,
     path.join(V2_RESOURCE_PATH, "job/ok_processing.json")
   );
+  return mockAgent;
 }
 
 describe("MindeeV2 - Client", () => {
@@ -56,7 +56,7 @@ describe("MindeeV2 - Client", () => {
   });
 
   beforeEach(async () => {
-    await setAllInterceptors();
+    const mockAgent = await setAllInterceptors();
     client = new Client({ apiKey: "dummy", debug: true, dispatcher: mockAgent });
   });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Hi Mindee Team,

We are using the Mindee Node.js SDK (`mindeeClient.enqueue()`) in a Next.js / Vercel Serverless environment. We are consistently hitting an `UND_ERR_SOCKET` ("other side closed") error on our API routes. Because Vercel pauses serverless execution between invocations, Keep-Alive sockets in the connection pool go stale. When the function wakes up for the next request, undici grabs a pooled socket that the Mindee API (or its load balancer) has already closed, resulting in an immediate crash at `bytesWritten: 0`.

We have tried multiple aggressive workarounds to completely disable connection reuse and Keep-Alive, but the SDK seems to bypass or ignore them:

**1. Using the SDK's `dispatcher` option**

We passed a custom undici Agent to strictly disable pipelining and keep-alive pools:

```typescript
import * as mindee from "mindee";
import { Agent } from "undici";

const mindeeClient = new mindee.Client({
  apiKey: process.env.MINDEE_API_KEY!,
  dispatcher: new Agent({
    pipelining: 0,
    keepAliveTimeout: 1,
    keepAliveMaxTimeout: 1
  }),
});
```

> Result: Still throws "other side closed"

**2. Monkey-patching `https.request`**

We tried intercepting Node's underlying https module to force `keepAlive: false`:

```typescript
const noKeepAliveAgent = new https.Agent({ keepAlive: false });
const originalHttpsRequest = https.request;
(https as any).request = function (url: any, options: any, cb: any) {
  if (typeof options === "object") options.agent = noKeepAliveAgent;
  return originalHttpsRequest(url, options, cb);
};
```

> Result: Still throws "other side closed"

**3. Setting Environment Variables**

We also added `MINDEE_REQUEST_TIMEOUT=60` and `NODE_TLS_REJECT_UNAUTHORIZED=0` to our Vercel environment.

Despite all of this, the SDK continues to grab closed sockets from a pool somewhere and fails.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
